### PR TITLE
Add TraceSink abstraction for pluggable trace storage

### DIFF
--- a/packages/agent-sdk/siili_ai_sdk/agent/base_agent.py
+++ b/packages/agent-sdk/siili_ai_sdk/agent/base_agent.py
@@ -26,6 +26,7 @@ from siili_ai_sdk.thread.models import BlockFullyAddedEvent, ThreadEvent, Thread
 from siili_ai_sdk.thread.thread_container import ThreadContainer
 from siili_ai_sdk.tools.tool_provider import ToolProvider
 from siili_ai_sdk.tracing.agent_trace import AgentTrace
+from siili_ai_sdk.tracing.trace_sink import TraceSink
 from siili_ai_sdk.utils.init_logger import init_logger
 
 logger = init_logger(__name__)
@@ -45,6 +46,7 @@ class BaseAgent(ABC):
         llm_model: Optional[LLMModel] = None,
         reasoning: Optional[bool] = None,
         trace: Optional[AgentTrace] = None,
+        trace_sink: Optional[TraceSink] = None,
         thread_container: Optional[ThreadContainer] = None,
         tools: Optional[List[BaseTool]] = None,
         tool_providers: Optional[List[ToolProvider]] = None,
@@ -55,7 +57,7 @@ class BaseAgent(ABC):
         logger.debug("Initializing BaseAgent")
         self.prompt_loader = prompt_loader or get_prompt_loader(prompt_loader_mode)
         self.system_prompt = system_prompt or self._get_system_prompt(system_prompt_args, system_prompt_version)
-        self.trace = trace or AgentTrace(self.system_prompt, self.__class__.__name__)
+        self.trace = trace or AgentTrace(self.system_prompt, self.__class__.__name__, trace_sink=trace_sink)
         self.thread_container = thread_container or ThreadContainer(self.system_prompt)
         self.tools = tools or self._create_tools(tool_providers)
         self.llm_config = llm_config or self.create_llm_config(llm_model, reasoning)

--- a/packages/agent-sdk/siili_ai_sdk/config/env.py
+++ b/packages/agent-sdk/siili_ai_sdk/config/env.py
@@ -5,6 +5,7 @@ from siili_ai_sdk.models.llm_model import LLMModel
 from siili_ai_sdk.models.model_registry import ModelRegistry
 from siili_ai_sdk.models.providers.provider_type import ProviderType
 from siili_ai_sdk.prompt.prompt_loader_mode import PromptLoaderMode
+from siili_ai_sdk.tracing.trace_sink_mode import TraceSinkMode
 
 
 class EnvConfig:
@@ -44,6 +45,9 @@ class EnvConfig:
 
     def get_prompt_loader_mode(self) -> PromptLoaderMode:
         return PromptLoaderMode.from_name(self.get_key("PROMPT_LOADER_MODE", "local"))
+
+    def get_trace_sink_mode(self) -> TraceSinkMode:
+        return TraceSinkMode.from_name(self.get_key("TRACE_SINK_MODE", "local"))
 
     def get_credentials_provider_type(self) -> str:
         return self.get_key("CREDENTIALS_PROVIDER_TYPE", "env")

--- a/packages/agent-sdk/siili_ai_sdk/tracing/__init__.py
+++ b/packages/agent-sdk/siili_ai_sdk/tracing/__init__.py
@@ -1,0 +1,13 @@
+from siili_ai_sdk.tracing.agent_trace import AgentTrace
+from siili_ai_sdk.tracing.get_trace_sink import get_trace_sink
+from siili_ai_sdk.tracing.local_trace_sink import LocalTraceSink
+from siili_ai_sdk.tracing.trace_sink import TraceSink
+from siili_ai_sdk.tracing.trace_sink_mode import TraceSinkMode
+
+__all__ = [
+    "AgentTrace",
+    "TraceSink",
+    "LocalTraceSink",
+    "TraceSinkMode",
+    "get_trace_sink",
+]

--- a/packages/agent-sdk/siili_ai_sdk/tracing/get_trace_sink.py
+++ b/packages/agent-sdk/siili_ai_sdk/tracing/get_trace_sink.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from siili_ai_sdk.tracing.local_trace_sink import LocalTraceSink
+from siili_ai_sdk.tracing.trace_sink import TraceSink
+from siili_ai_sdk.tracing.trace_sink_mode import TraceSinkMode
+
+
+def get_trace_sink(mode: Optional[TraceSinkMode] = None) -> TraceSink:
+    # Lazy import to avoid circular dependency with env.py
+    from siili_ai_sdk.config.env import env_config
+
+    mode = mode or env_config.get_trace_sink_mode()
+    if mode == TraceSinkMode.LOCAL:
+        return LocalTraceSink()
+    raise ValueError(f"Unknown TraceSinkMode: {mode}")

--- a/packages/agent-sdk/siili_ai_sdk/tracing/local_trace_sink.py
+++ b/packages/agent-sdk/siili_ai_sdk/tracing/local_trace_sink.py
@@ -1,0 +1,23 @@
+import os
+from typing import Optional
+
+from siili_ai_sdk.tracing.trace_sink import TraceSink
+
+
+class LocalTraceSink(TraceSink):
+    """TraceSink implementation that writes traces to the local filesystem."""
+
+    def __init__(self, traces_dir: Optional[str] = None):
+        self.traces_dir = traces_dir or "traces"
+
+    def save_trace(self, name: str, trace_content: str, system_prompt: str) -> None:
+        os.makedirs(self.traces_dir, exist_ok=True)
+
+        trace_path = os.path.join(self.traces_dir, f"{name}.txt")
+        system_prompt_path = os.path.join(self.traces_dir, f"{name}_system_prompt.txt")
+
+        with open(trace_path, "w", encoding="utf-8") as f:
+            f.write(trace_content)
+
+        with open(system_prompt_path, "w", encoding="utf-8") as f:
+            f.write(system_prompt)

--- a/packages/agent-sdk/siili_ai_sdk/tracing/trace_sink.py
+++ b/packages/agent-sdk/siili_ai_sdk/tracing/trace_sink.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+
+
+class TraceSink(ABC):
+    """Abstract base class for trace storage backends.
+
+    Implementations can write traces to local files, remote APIs, databases, etc.
+    """
+
+    @abstractmethod
+    def save_trace(self, name: str, trace_content: str, system_prompt: str) -> None:
+        """Save a trace with its system prompt.
+
+        Args:
+            name: Identifier for the trace (e.g., agent class name)
+            trace_content: The formatted trace content (without system prompt)
+            system_prompt: The system prompt used for the agent
+        """
+        pass

--- a/packages/agent-sdk/siili_ai_sdk/tracing/trace_sink_mode.py
+++ b/packages/agent-sdk/siili_ai_sdk/tracing/trace_sink_mode.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class TraceSinkMode(Enum):
+    LOCAL = "local"
+
+    @classmethod
+    def from_name(cls, name: str) -> "TraceSinkMode":
+        for mode in cls:
+            if mode.value == name:
+                return mode
+
+        available_modes = [mode.value for mode in cls]
+        raise ValueError(f"Unknown TraceSinkMode '{name}'. Available: {', '.join(available_modes)}")


### PR DESCRIPTION
Follows the PromptLoader pattern to allow swapping trace storage backends. By default traces go to local files, but can be configured for remote APIs via the trace_sink parameter on BaseAgent or TRACE_SINK_MODE env var.