### PR TITLE
Add release environment to workflows

### DIFF
--- a/.github/workflows/release-agent-sdk.yml
+++ b/.github/workflows/release-agent-sdk.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     env:
@@ -91,4 +92,3 @@ jobs:
           git commit -m "chore: bump spaik-sdk version to ${{ steps.new_version.outputs.version }}"
           git tag "spaik-sdk-v${{ steps.new_version.outputs.version }}"
           git push origin HEAD --tags
-

--- a/.github/workflows/release-agent-workflows.yml
+++ b/.github/workflows/release-agent-workflows.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     defaults:

--- a/.github/workflows/release-coding-agents.yml
+++ b/.github/workflows/release-coding-agents.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     defaults:
@@ -95,4 +96,3 @@ jobs:
         run: |
           git tag "spaik-coding-agents-v${{ steps.new_version.outputs.version }}"
           git push origin HEAD --tags
-

--- a/.github/workflows/release-hooks.yml
+++ b/.github/workflows/release-hooks.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release-material.yml
+++ b/.github/workflows/release-material.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Summary
Add environment: release to all release workflow jobs to enable GitHub environment protection rules

Changes
release-agent-sdk.yml - Added release environment
release-agent-workflows.yml - Added release environment
release-coding-agents.yml - Added release environment
release-hooks.yml - Added release environment
release-material.yml - Added release environment

Why
This enables the use of GitHub environment protection rules (such as required reviewers or deployment branches) for release workflows, providing an additional layer of control over package publishing.