### PR TITLE
feat(agent): add spawn() for isolated subagent execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ print(agent.get_response_text("What's the weather in Helsinki?"))
 - `get_response_stream(input)` - Async generator for streaming
 - `get_event_stream(input)` - Async generator for ThreadEvents
 - `get_structured_response(prompt, Schema)` - Returns Pydantic model
+- `spawn(task)` - Run as isolated subagent (prevents LangChain callback leaks)
 - `run_cli()` - Interactive CLI mode
 
 ### FastAPI Server

--- a/examples/agents/subagent_example.py
+++ b/examples/agents/subagent_example.py
@@ -1,0 +1,72 @@
+"""
+Demonstrates spawning a nested agent from inside a tool without leaking
+the parent agent's LangChain callback context.
+
+Without isolation the subagent's tool calls bleed into the parent thread.
+With spawn() they stay inside the subagent's own ThreadContainer.
+
+Run:
+    uv run python examples/agents/subagent_example.py
+"""
+
+from dotenv import load_dotenv
+
+from spaik_sdk.agent.base_agent import BaseAgent
+from spaik_sdk.thread.models import MessageBlockType
+from spaik_sdk.tools.tool_provider import BaseTool, ToolProvider, tool
+
+
+class EchoTools(ToolProvider):
+    def get_tools(self) -> list[BaseTool]:
+        @tool
+        def echo(message: str) -> str:
+            """Echo the message back."""
+            return message
+
+        return [echo]
+
+
+class SubAgent(BaseAgent):
+    def get_tool_providers(self) -> list[ToolProvider]:
+        return [EchoTools()]
+
+
+class SpawnTools(ToolProvider):
+    def get_tools(self) -> list[BaseTool]:
+        @tool
+        def spawn_sub(task: str) -> str:
+            """Delegate a task to a subagent that echoes the message."""
+            sub = SubAgent(system_prompt="Use the echo tool to echo the message exactly.")
+            msg = sub.spawn(task)
+            return msg.get_text_content()
+
+        return [spawn_sub]
+
+
+class MainAgent(BaseAgent):
+    def get_tool_providers(self) -> list[ToolProvider]:
+        return [SpawnTools()]
+
+
+def main() -> None:
+    agent = MainAgent(system_prompt="Use spawn_sub to delegate tasks.")
+    response = agent.get_response("Spawn a subagent that echoes: hello world")
+
+    parent_tool_names = [
+        b.tool_name
+        for b in response.blocks
+        if b.type == MessageBlockType.TOOL_USE and b.tool_name is not None
+    ]
+    print(f"Parent thread tool calls: {parent_tool_names}")
+    print("  -> should only contain ['spawn_sub'], not 'echo'")
+
+    assert parent_tool_names == ["spawn_sub"], (
+        f"Expected only ['spawn_sub'] but got {parent_tool_names}. "
+        "The subagent's tool calls leaked into the parent thread."
+    )
+    print("\nAll good — subagent context isolated correctly.")
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    main()

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -131,6 +131,23 @@ class MyAgent(BaseAgent):
         ]
 ```
 
+## Subagents
+
+To call one agent from inside another agent's tool, use `spawn()` instead of `get_response()`. This prevents LangChain's callback context from leaking into the subagent, which would otherwise cause the subagent's internal tool calls to appear in the parent thread.
+
+```python
+class ResearchTools(ToolProvider):
+    def get_tools(self) -> list[BaseTool]:
+        @tool
+        def research(topic: str) -> str:
+            """Delegate a research task to a specialist subagent."""
+            sub = ResearchAgent(system_prompt="You are a research specialist.")
+            return sub.spawn(topic).get_text_content()
+        return [research]
+```
+
+For cases where you need to isolate an arbitrary coroutine rather than a full agent call, use the static `BaseAgent.run_isolated(coro)` helper directly.
+
 ## Models
 
 ```python

--- a/packages/agent-sdk/spaik_sdk/agent/base_agent.py
+++ b/packages/agent-sdk/spaik_sdk/agent/base_agent.py
@@ -1,4 +1,6 @@
 import asyncio
+import contextvars
+import threading
 import uuid
 from abc import ABC
 from typing import Any, AsyncGenerator, Dict, List, Optional, Type, TypeVar
@@ -139,6 +141,42 @@ class BaseAgent(ABC):
         attachments: Optional[List[Attachment]] = None,
     ) -> str:
         return (await self.get_response_async(user_input, attachments)).get_text_content()
+
+    def spawn(
+        self,
+        task: str,
+        attachments: Optional[List[Attachment]] = None,
+    ) -> "ThreadMessage":
+        """Run this agent as an isolated subagent.
+
+        Prevents LangChain callback context from leaking into this agent's thread,
+        which would cause the subagent's tool calls to appear in the parent thread.
+        """
+        return BaseAgent.run_isolated(self.get_response_async(task, attachments))
+
+    @staticmethod
+    def run_isolated(coro: Any) -> Any:
+        """Run a coroutine in a blank ContextVar context.
+
+        Use this when calling a nested agent from inside a tool so that LangChain's
+        callback handlers (stored in ContextVars) are not inherited by the subagent.
+        """
+        result: list = []
+        error: list = []
+
+        def _thread() -> None:
+            ctx = contextvars.Context()
+            try:
+                ctx.run(lambda: result.append(asyncio.run(coro)))
+            except Exception as exc:
+                error.append(exc)
+
+        t = threading.Thread(target=_thread)
+        t.start()
+        t.join()
+        if error:
+            raise error[0]
+        return result[0]
 
     def get_structured_response(self, prompt: str, output_schema: Type[T]) -> T:
         self.trace.add_structured_response_input(prompt, output_schema)

--- a/packages/agent-sdk/tests/unit/spaik_sdk/agent/test_base_agent.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/agent/test_base_agent.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextvars
 import time
 import uuid
 from typing import List, Optional
@@ -361,3 +363,91 @@ class TestBaseAgentInstanceId:
 
         # The agent's instance ID should match the trace's instance ID
         assert agent.agent_instance_id == agent.trace.agent_instance_id
+
+
+@pytest.mark.unit
+class TestRunIsolated:
+    """Tests for BaseAgent.run_isolated() and spawn() context isolation."""
+
+    def test_run_isolated_does_not_inherit_context_var(self):
+        """A ContextVar set in the parent is invisible inside run_isolated."""
+        _var: contextvars.ContextVar[str | None] = contextvars.ContextVar("_test_isolation", default=None)
+        _var.set("parent_value")
+
+        async def read_var() -> str | None:
+            return _var.get()
+
+        result = BaseAgent.run_isolated(read_var())
+        assert result is None
+
+    def test_run_isolated_returns_coroutine_result(self):
+        """run_isolated returns whatever the coroutine resolves to."""
+
+        async def compute() -> int:
+            return 42
+
+        assert BaseAgent.run_isolated(compute()) == 42
+
+    def test_run_isolated_propagates_exceptions(self):
+        """Exceptions raised inside the coroutine are re-raised by run_isolated."""
+
+        async def boom() -> None:
+            raise ValueError("inner error")
+
+        with pytest.raises(ValueError, match="inner error"):
+            BaseAgent.run_isolated(boom())
+
+    def test_spawn_uses_isolated_context(self):
+        """spawn() executes get_response_async in a blank context.
+
+        Simulates the LangChain callback leak scenario: a ContextVar is set before
+        calling spawn() (as it would be during normal agent execution) and verified
+        to be absent inside the spawned coroutine.
+        """
+        _callback_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("_lc_callbacks", default=None)
+        _callback_var.set("fake_langchain_handler")
+
+        from unittest.mock import MagicMock
+
+        context_seen_by_spawn: list[str | None] = []
+        fake_message = MagicMock()
+
+        async def mock_response_async(
+            user_input: str | None = None,
+            attachments: object = None,
+        ) -> object:
+            context_seen_by_spawn.append(_callback_var.get())
+            return fake_message
+
+        agent = ConcreteTestAgent(recording_name="test_spawn_isolation")
+        agent.get_response_async = mock_response_async  # type: ignore[method-assign]
+
+        agent.spawn("test task")
+
+        assert context_seen_by_spawn == [None], f"spawn() leaked a parent ContextVar into the subagent. Got: {context_seen_by_spawn}"
+
+    def test_run_isolated_can_be_called_concurrently(self):
+        """Multiple run_isolated calls don't interfere with each other."""
+        import threading as _threading
+
+        results: list[int] = []
+        errors: list[Exception] = []
+
+        async def slow_compute(value: int) -> int:
+            await asyncio.sleep(0.01)
+            return value * 2
+
+        def _run(v: int) -> None:
+            try:
+                results.append(BaseAgent.run_isolated(slow_compute(v)))
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [_threading.Thread(target=_run, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert sorted(results) == [0, 2, 4, 6, 8]


### PR DESCRIPTION
## Problem

When a tool spawns a nested `BaseAgent` using `asyncio.run()`, the subagent inherits the calling coroutine's `contextvars` context. LangChain stores its active callback handlers there, so the subagent's tool calls get routed through the parent's `MessageHandler` and bleed into the parent thread — cluttering the UI and breaking the "subagent in a box" pattern.

## Solution

Two new methods on `BaseAgent`:

- **`spawn(task, attachments=None) → ThreadMessage`** — the primary API. Runs the subagent as an isolated call, preventing callback context from leaking. Drop-in replacement for `asyncio.run(sub.get_response_async(task))` inside a tool.
- **`BaseAgent.run_isolated(coro) → Any`** — static helper for the rare case where you need to isolate an arbitrary coroutine rather than a full agent response.

The fix works by running the coroutine in a fresh OS thread with a blank `contextvars.Context()`. A blank context has no inherited `ContextVar` values, so LangChain's callbacks are absent and the subagent's events stay inside its own `ThreadContainer`.

## Changes

- `spaik_sdk/agent/base_agent.py` — `spawn()` + `run_isolated()` added
- `examples/agents/subagent_example.py` — runnable demo: MainAgent → tool → SubAgent with echo tool, asserts only `spawn_sub` appears in parent thread
- `tests/unit/spaik_sdk/agent/test_base_agent.py` — `TestRunIsolated` class with 5 tests:
  - ContextVar set in parent is not visible inside `run_isolated`
  - Return value passes through correctly
  - Exceptions propagate out of the isolated run
  - `spawn()` doesn't leak parent ContextVar into the subagent (the exact bug scenario)
  - Concurrent `run_isolated` calls don't interfere
- `packages/agent-sdk/README.md` — new Subagents section
- `AGENTS.md` — `spawn()` added to Agent Methods list

## Usage

```python
class ResearchTools(ToolProvider):
    def get_tools(self) -> list[BaseTool]:
        @tool
        def research(topic: str) -> str:
            """Delegate to a specialist subagent."""
            sub = ResearchAgent(system_prompt="You are a research specialist.")
            return sub.spawn(topic).get_text_content()
        return [research]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `spawn()` method to run agents as isolated subagents within tool calls
  * Added static `run_isolated()` helper method for executing isolated coroutines

* **Documentation**
  * Added "Subagents" section to agent documentation explaining how to invoke agents from within other agents' tools

* **Examples**
  * Added new subagent example demonstrating nested agent invocation patterns

* **Tests**
  * Added unit tests validating isolation behavior for new methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->