### PR TITLE
Fix subagent silent-death from tool errors and event-loop starvation (#61)

### DIFF
--- a/packages/agent-sdk/spaik_sdk/llm/langchain_service.py
+++ b/packages/agent-sdk/spaik_sdk/llm/langchain_service.py
@@ -10,7 +10,7 @@ from langchain_core.tools import BaseTool
 # Using create_react_agent because create_agent from langchain.agents
 # uses invoke() internally and does NOT emit on_chat_model_stream events,
 # which breaks token-level streaming. See: https://github.com/langchain-ai/langchain/issues/34017
-from langgraph.prebuilt import create_react_agent  # type: ignore[deprecated]
+from langgraph.prebuilt import ToolNode, create_react_agent  # type: ignore[deprecated]
 from pydantic import BaseModel
 
 from spaik_sdk.attachments.file_storage_provider import get_file_storage
@@ -76,7 +76,13 @@ class LangChainService:
         self.cancellation_handle = cancellation_handle
 
     def create_executor(self, tools: list[BaseTool]):
-        return create_react_agent(self._get_model(), tools)  # type: ignore[deprecated]
+        # Wrap tools in a ToolNode with handle_tool_errors=True so runtime tool
+        # exceptions (network errors, HTTP errors, etc.) become ToolMessage
+        # errors the LLM can react to, instead of escaping and crashing the
+        # agent loop. The LangGraph default re-raises anything that isn't a
+        # tool-arg validation error, which kills streaming mid-run.
+        tool_node = ToolNode(tools, handle_tool_errors=True)
+        return create_react_agent(self._get_model(), tool_node)  # type: ignore[deprecated]
 
     def _get_model(self):
         return self.llm_config.get_model_wrapper().get_langchain_model()

--- a/packages/agent-sdk/spaik_sdk/llm/langchain_service.py
+++ b/packages/agent-sdk/spaik_sdk/llm/langchain_service.py
@@ -76,11 +76,8 @@ class LangChainService:
         self.cancellation_handle = cancellation_handle
 
     def create_executor(self, tools: list[BaseTool]):
-        # Wrap tools in a ToolNode with handle_tool_errors=True so runtime tool
-        # exceptions (network errors, HTTP errors, etc.) become ToolMessage
-        # errors the LLM can react to, instead of escaping and crashing the
-        # agent loop. The LangGraph default re-raises anything that isn't a
-        # tool-arg validation error, which kills streaming mid-run.
+        # handle_tool_errors=True: the LangGraph default re-raises non-validation
+        # tool exceptions, which kills the agent loop silently. See issue #61.
         tool_node = ToolNode(tools, handle_tool_errors=True)
         return create_react_agent(self._get_model(), tool_node)  # type: ignore[deprecated]
 

--- a/packages/agent-sdk/spaik_sdk/llm/langchain_service.py
+++ b/packages/agent-sdk/spaik_sdk/llm/langchain_service.py
@@ -10,6 +10,7 @@ from langchain_core.tools import BaseTool
 # Using create_react_agent because create_agent from langchain.agents
 # uses invoke() internally and does NOT emit on_chat_model_stream events,
 # which breaks token-level streaming. See: https://github.com/langchain-ai/langchain/issues/34017
+from langgraph.graph.state import CompiledStateGraph
 from langgraph.prebuilt import ToolNode, create_react_agent  # type: ignore[deprecated]
 from pydantic import BaseModel
 
@@ -75,7 +76,7 @@ class LangChainService:
         self.playback = playback
         self.cancellation_handle = cancellation_handle
 
-    def create_executor(self, tools: list[BaseTool]):
+    def create_executor(self, tools: list[BaseTool]) -> CompiledStateGraph:
         # handle_tool_errors=True: the LangGraph default re-raises non-validation
         # tool exceptions, which kills the agent loop silently. See issue #61.
         tool_node = ToolNode(tools, handle_tool_errors=True)

--- a/packages/agent-sdk/spaik_sdk/thread/adapters/sync_adapter.py
+++ b/packages/agent-sdk/spaik_sdk/thread/adapters/sync_adapter.py
@@ -60,9 +60,7 @@ class SyncAdapter:
                 # Give it a moment to finalize
                 await asyncio.sleep(0.1)
                 return self.container.get_latest_ai_message()
-            # Yield to the event loop so this coroutine does not seize it.
-            # Without this, the loop spins without awaiting anything, blocking
-            # every other task until `timeout` elapses.
+            # Yield to the event loop; without this the poll starves siblings (#61).
             await asyncio.sleep(0.01)
 
         # Timeout - return what we have

--- a/packages/agent-sdk/spaik_sdk/thread/adapters/sync_adapter.py
+++ b/packages/agent-sdk/spaik_sdk/thread/adapters/sync_adapter.py
@@ -60,6 +60,10 @@ class SyncAdapter:
                 # Give it a moment to finalize
                 await asyncio.sleep(0.1)
                 return self.container.get_latest_ai_message()
+            # Yield to the event loop so this coroutine does not seize it.
+            # Without this, the loop spins without awaiting anything, blocking
+            # every other task until `timeout` elapses.
+            await asyncio.sleep(0.01)
 
         # Timeout - return what we have
         return self.container.get_latest_ai_message()

--- a/packages/agent-sdk/tests/unit/spaik_sdk/llm/test_langchain_service_tool_errors.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/llm/test_langchain_service_tool_errors.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.tools import tool
+
+from spaik_sdk.llm.langchain_service import LangChainService
+
+
+@pytest.mark.unit
+class TestCreateExecutorToolErrorHandling:
+    def test_wraps_tools_in_tool_node_with_error_handling(self):
+        # Regression test for issue #61: the LangGraph default tool error
+        # handler re-raises any runtime tool exception, killing the agent
+        # loop. We now wrap tools in a ToolNode with handle_tool_errors=True
+        # so errors become ToolMessage errors the LLM can react to.
+        @tool
+        def sample_tool(x: int) -> int:
+            """Sample tool."""
+            return x
+
+        service = LangChainService(
+            llm_config=MagicMock(),
+            thread_container=MagicMock(thread_id="t"),
+            assistant_name="a",
+            assistant_id="a",
+        )
+
+        fake_model = object()
+        with patch.object(LangChainService, "_get_model", return_value=fake_model):
+            with patch("spaik_sdk.llm.langchain_service.create_react_agent") as mock_create:
+                with patch("spaik_sdk.llm.langchain_service.ToolNode") as mock_tool_node:
+                    mock_tool_node.return_value = "tool-node-sentinel"
+                    service.create_executor([sample_tool])
+
+        mock_tool_node.assert_called_once_with([sample_tool], handle_tool_errors=True)
+        mock_create.assert_called_once_with(fake_model, "tool-node-sentinel")

--- a/packages/agent-sdk/tests/unit/spaik_sdk/llm/test_langchain_service_tool_errors.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/llm/test_langchain_service_tool_errors.py
@@ -9,10 +9,6 @@ from spaik_sdk.llm.langchain_service import LangChainService
 @pytest.mark.unit
 class TestCreateExecutorToolErrorHandling:
     def test_wraps_tools_in_tool_node_with_error_handling(self):
-        # Regression test for issue #61: the LangGraph default tool error
-        # handler re-raises any runtime tool exception, killing the agent
-        # loop. We now wrap tools in a ToolNode with handle_tool_errors=True
-        # so errors become ToolMessage errors the LLM can react to.
         @tool
         def sample_tool(x: int) -> int:
             """Sample tool."""

--- a/packages/agent-sdk/tests/unit/spaik_sdk/thread/adapters/test_sync_adapter.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/thread/adapters/test_sync_adapter.py
@@ -1,0 +1,74 @@
+import asyncio
+import time
+
+import pytest
+
+from spaik_sdk.thread.adapters.sync_adapter import SyncAdapter
+from spaik_sdk.thread.models import MessageBlock, MessageBlockType, ThreadMessage
+from spaik_sdk.thread.thread_container import ThreadContainer
+
+
+def _streaming_container() -> ThreadContainer:
+    # Build a container that reports active streaming so the early-return
+    # branch of SyncAdapter.wait_for_completion_async never fires.
+    container = ThreadContainer()
+    container.messages.append(
+        ThreadMessage(
+            id="m-1",
+            ai=True,
+            author_id="assistant",
+            author_name="assistant",
+            timestamp=0,
+            blocks=[MessageBlock(id="b-1", streaming=True, type=MessageBlockType.PLAIN, content="")],
+        )
+    )
+    assert container.is_streaming_active() is True
+    return container
+
+
+@pytest.mark.unit
+class TestSyncAdapterWaitForCompletion:
+    async def test_yields_to_event_loop_while_waiting(self):
+        # Regression test for subagent freeze (issue #61).
+        #
+        # Previously `wait_for_completion_async` spun on `time.time()` without
+        # awaiting anything when the stream had not yet ended, seizing the
+        # event loop for the entire timeout. A concurrent coroutine would be
+        # unable to make progress until the adapter returned.
+        container = _streaming_container()
+        adapter = SyncAdapter(container)
+
+        ticks = 0
+
+        async def tick():
+            nonlocal ticks
+            while ticks < 3:
+                ticks += 1
+                await asyncio.sleep(0.01)
+
+        start = time.time()
+        await asyncio.wait_for(
+            asyncio.gather(adapter.wait_for_completion_async(timeout=0.2), tick()),
+            timeout=1.0,
+        )
+        elapsed = time.time() - start
+
+        assert ticks == 3
+        assert elapsed < 0.5
+
+    async def test_returns_promptly_once_streaming_ends(self):
+        container = ThreadContainer()
+        adapter = SyncAdapter(container)
+
+        async def end_streaming_soon():
+            await asyncio.sleep(0.05)
+            adapter._streaming_ended = True
+
+        start = time.time()
+        await asyncio.gather(
+            adapter.wait_for_completion_async(timeout=5.0),
+            end_streaming_soon(),
+        )
+        elapsed = time.time() - start
+
+        assert elapsed < 1.0

--- a/packages/agent-sdk/tests/unit/spaik_sdk/thread/adapters/test_sync_adapter.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/thread/adapters/test_sync_adapter.py
@@ -29,29 +29,31 @@ def _streaming_container() -> ThreadContainer:
 class TestSyncAdapterWaitForCompletion:
     async def test_yields_to_event_loop_while_waiting(self):
         # Regression for #61: the polling loop used to seize the event loop.
+        # A sibling task running alongside the wait must get CPU time *during*
+        # the poll, not only after it returns.
         container = _streaming_container()
         adapter = SyncAdapter(container)
 
         ticks = 0
+        adapter_done = False
 
         async def tick():
             nonlocal ticks
-            while ticks < 3:
+            while not adapter_done:
                 ticks += 1
-                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.005)
 
-        start = time.time()
-        await asyncio.wait_for(
-            asyncio.gather(adapter.wait_for_completion_async(timeout=0.2), tick()),
-            timeout=1.0,
-        )
-        elapsed = time.time() - start
+        tick_task = asyncio.create_task(tick())
+        await adapter.wait_for_completion_async(timeout=0.2)
+        adapter_done = True
+        await tick_task
 
-        assert ticks == 3
-        assert elapsed < 0.5
+        # With the bug the sibling was starved for the full 0.2s and reported 0
+        # ticks. With the fix it runs every ~5ms, so expect well over 10.
+        assert ticks > 10
 
     async def test_returns_promptly_once_streaming_ends(self):
-        container = ThreadContainer()
+        container = _streaming_container()
         adapter = SyncAdapter(container)
 
         async def end_streaming_soon():

--- a/packages/agent-sdk/tests/unit/spaik_sdk/thread/adapters/test_sync_adapter.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/thread/adapters/test_sync_adapter.py
@@ -9,8 +9,7 @@ from spaik_sdk.thread.thread_container import ThreadContainer
 
 
 def _streaming_container() -> ThreadContainer:
-    # Build a container that reports active streaming so the early-return
-    # branch of SyncAdapter.wait_for_completion_async never fires.
+    # Keeps the adapter in its polling loop (no early return).
     container = ThreadContainer()
     container.messages.append(
         ThreadMessage(
@@ -29,12 +28,7 @@ def _streaming_container() -> ThreadContainer:
 @pytest.mark.unit
 class TestSyncAdapterWaitForCompletion:
     async def test_yields_to_event_loop_while_waiting(self):
-        # Regression test for subagent freeze (issue #61).
-        #
-        # Previously `wait_for_completion_async` spun on `time.time()` without
-        # awaiting anything when the stream had not yet ended, seizing the
-        # event loop for the entire timeout. A concurrent coroutine would be
-        # unable to make progress until the adapter returned.
+        # Regression for #61: the polling loop used to seize the event loop.
         container = _streaming_container()
         adapter = SyncAdapter(container)
 


### PR DESCRIPTION
# Fix subagent silent-death from tool errors and event-loop starvation (#61)

Closes #61 (partial — bugs 2 and 3 only; see "Out of scope" below).

## Summary

Two independent bugs in `spaik-sdk` combined to make subagents look frozen
when anything went wrong during a run. Both are fixed here; both have
regression tests that would fail against the old code.

### Bug — runtime tool exceptions escape the agent loop

`LangChainService.create_executor` used `create_react_agent(model, tools)`
with no `ToolNode` configuration, which picks up LangGraph's default error
handler. That handler only catches argument-validation errors and
re-raises everything else — a content-filter 4xx, `urllib.error.HTTPError`,
`ConnectionError`, or any raised exception from a tool propagates out of
the graph and kills the agent loop. The LLM never sees the error and
never gets a chance to retry or recover. On a subagent this also means
the parent agent's `spawn` call dies with `ValueError("No response
received")` and no useful diagnostics.

Wrap tools in `ToolNode(tools, handle_tool_errors=True)` so runtime tool
exceptions become `ToolMessage(status="error")` the LLM can react to.

Reproduction (minimal LangGraph, no LLM call needed):

```
Default ToolNode          : raised ConnectionError: boom: 1
handle_tool_errors=True   : ToolMessage status=error content="Error: ConnectionError('boom: 1')\n Please fix your mistakes."
```

### Bug — `SyncAdapter.wait_for_completion_async` seizes the event loop

The polling loop had no `await` on the not-ready branch, so while
streaming was still active the coroutine spun on `time.time()` without
yielding. Because `get_response_async` calls this method twice (once
from `run_async`, once directly) this added up to 60s of frozen event
loop on top of any upstream error that ended streaming early.

Adding `await asyncio.sleep(0.01)` in the loop lets other coroutines
(including the one watching for cancellation) make progress while we
wait.

Reproduction — a sibling coroutine ticking every 5ms alongside a
0.5s `wait_for_completion_async`:

```
Before fix: elapsed=0.500s ticks_during_wait=0    (event loop starved)
After  fix: elapsed=0.507s ticks_during_wait=92   (event loop free)
```

## Changes

| File | Change |
|---|---|
| `spaik_sdk/llm/langchain_service.py` | Wrap tools in `ToolNode(tools, handle_tool_errors=True)` before passing to `create_react_agent`. |
| `spaik_sdk/thread/adapters/sync_adapter.py` | `await asyncio.sleep(0.01)` at the end of the polling loop body. |
| `tests/unit/spaik_sdk/llm/test_langchain_service_tool_errors.py` | New — asserts `create_executor` wires `ToolNode` with `handle_tool_errors=True`. |
| `tests/unit/spaik_sdk/thread/adapters/test_sync_adapter.py` | New — asserts the poll yields to the event loop while streaming is active, and returns promptly once streaming ends. |

## Out of scope (deliberately not in this PR)

The reporter's "Bug 1" (unbounded `t.join()` in `BaseAgent.run_isolated`
combined with a 600s httpx read timeout and 2 retries) is real but
**not** fixed here. The proposed mitigation — setting a 120s request
timeout on `ChatOpenAI`/`ChatAnthropic` — would be measured per-chunk,
not per-call, and while that's enough for the streaming agent path it
caps `get_structured_response` (which uses `.invoke()`) at 120s total.
More importantly, a blanket HTTP-layer timeout conflates "stalled
socket" with "model is taking its time on a hard task." The right
layer for that fix is `run_isolated` itself (e.g. a bounded
`t.join(timeout=...)` with a generous wall clock), which will be
handled separately.

## Verification

- `make lint` — clean
- `make typecheck` — clean
- `make test-unit` — 265 passed
- Bug 2 reproducer: 0 ticks (before) vs 92 ticks (after) during a 0.5s poll
- Bug 3 reproducer: `ConnectionError` escapes graph (before) vs `ToolMessage(status="error")` (after)

## Risk

Low. Both changes are narrowly scoped:

- `ToolNode(handle_tool_errors=True)` changes the format the LLM sees
  when a tool raises — the LLM is now told about the error instead of
  the stream dying. Existing tests for the tool-call happy path are
  unaffected (all 265 unit tests still pass).
- The extra `await asyncio.sleep(0.01)` only adds up to ~10ms of
  latency before `wait_for_completion_async` notices that streaming
  has ended; the existing 100ms "finalize" sleep in the ready branch
  is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool execution error handling to prevent agent loop termination on tool-related exceptions.
  * Enhanced event-loop responsiveness during streaming operations through explicit control yielding.

* **Tests**
  * Added comprehensive test coverage for tool error handling in agent execution.
  * Added regression tests for streaming completion responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->