### PR TITLE
fix(thread): emit BlockFullyAddedEvent for tool-use blocks

### DIFF
--- a/packages/agent-sdk/spaik_sdk/thread/thread_container.py
+++ b/packages/agent-sdk/spaik_sdk/thread/thread_container.py
@@ -130,49 +130,35 @@ class ThreadContainer:
                 break
 
     def add_tool_call_response(self, response: ToolCallResponse) -> None:
-        """Add a tool call response by its ID"""
+        """Record a tool call response and finalize the matching tool-use block."""
         self.tool_call_responses[response.id] = response
 
-        # Find the corresponding block ID
-        block_id = None
+        target_message_id: Optional[str] = None
+        target_block: Optional[MessageBlock] = None
         for message in self.messages:
             for block in message.blocks:
                 if block.tool_call_id == response.id:
-                    block.streaming = False
                     block.tool_call_response = response.response
                     block.tool_call_error = response.error
-                    block_id = block.id
+                    target_block = block
+                    target_message_id = message.id
                     break
-            if block_id:
+            if target_block is not None:
                 break
 
-        # Emit tool response event
+        block_id = target_block.id if target_block is not None else None
         self._emit_event(
             ToolResponseReceivedEvent(tool_call_id=response.id, response=response.response, error=response.error, block_id=block_id)
         )
 
+        if target_block is not None and target_message_id is not None:
+            self._mark_block_complete(target_message_id, target_block)
+
         self._increment_version()
 
     def update_tool_use_block_with_response(self, tool_call_id: str, response: str, error: Optional[str] = None) -> None:
-        """Update a tool use block with the tool response and mark it as completed."""
-        logger.debug(f"🔧 DEBUG: Updating tool response for {tool_call_id}")
-        logger.debug(f"🔧 DEBUG: Response: {response[:100]}...")
-        logger.debug(f"🔧 DEBUG: Error: {error}")
-
-        # Add the tool response to our responses dict
-        tool_response = ToolCallResponse(id=tool_call_id, response=response, error=error)
-        self.add_tool_call_response(tool_response)
-
-        # Find the message and block with this tool_call_id and mark it as non-streaming
-        for message in self.messages:
-            for block in message.blocks:
-                if block.tool_call_id == tool_call_id:
-                    block.streaming = False
-                    logger.debug(f"🔧 DEBUG: Found and updated block {block.id} for tool {tool_call_id}")
-                    self._increment_version()
-                    return
-
-        logger.debug(f"🔧 DEBUG: Could not find block for tool_call_id: {tool_call_id}")
+        """Record a tool response and finalize its block. Thin wrapper over add_tool_call_response."""
+        self.add_tool_call_response(ToolCallResponse(id=tool_call_id, response=response, error=error))
 
     def add_error_message(self, error_text: str, author_id: str = "system", author_name: str = "system") -> str:
         """Add an error message and return the message ID"""
@@ -197,65 +183,50 @@ class ThreadContainer:
 
     def finalize_streaming_blocks(self, message_id: str, block_ids: List[str]) -> None:
         """Mark specified blocks as non-streaming (completed)."""
-        completed_blocks = []
+        completed_blocks: List[str] = []
 
         for message in self.messages:
-            if message.id == message_id:
-                for block in message.blocks:
-                    if block.id in block_ids and block.streaming:
-                        block.streaming = False
-                        # Move content from streaming_content to block.content when streaming finishes
-                        if block.id in self.streaming_content:
-                            block.content = self.streaming_content[block.id]
-                            # lets not do this, access is needed at least for now
-                            # # Optionally remove from streaming_content to save memory
-                            # del self.streaming_content[block.id]
-                        completed_blocks.append(block.id)
-
-                        # Emit block fully added event for each completed block
-                        self._emit_event(
-                            BlockFullyAddedEvent(
-                                block_id=block.id,
-                                message_id=message_id,
-                                block=self._copy_block_without_live_provider(block),
-                            )
-                        )
-                break
+            if message.id != message_id:
+                continue
+            for block in message.blocks:
+                if block.id in block_ids and self._mark_block_complete(message_id, block):
+                    completed_blocks.append(block.id)
+            break
 
         if completed_blocks:
             self._increment_version()
-
-            # Check if streaming has ended
             if not self.is_streaming_active():
                 self._emit_event(StreamingEndedEvent(message_id=message_id, completed_blocks=completed_blocks))
 
     def cancel_generation(self) -> None:
-        """Cancel the generation"""
+        """Cancel the generation and finalize any in-flight blocks."""
         logger.info(f"Cancelling generation. Current streaming content: {self.streaming_content}")
-        logger.info(f"Messages: {self.messages}")
         for message in self.messages:
-            completed_blocks = []
+            completed_blocks: List[str] = []
             for block in message.blocks:
-                block.streaming = False
-                # Move content from streaming_content to block.content when streaming finishes
-                if block.id in self.streaming_content:
-                    block.content = self.streaming_content[block.id]
-                    logger.info(f"🔧 Block {block.id} content: {block.content}")
-                completed_blocks.append(block.id)
-                self._emit_event(
-                    BlockFullyAddedEvent(
-                        block_id=block.id,
-                        message_id=message.id,
-                        block=self._copy_block_without_live_provider(block),
-                    )
-                )
-            self.finalize_streaming_blocks(message.id, completed_blocks)
-        if completed_blocks:
-            self._increment_version()
+                if self._mark_block_complete(message.id, block):
+                    completed_blocks.append(block.id)
+            if completed_blocks:
+                self._increment_version()
+                if not self.is_streaming_active():
+                    self._emit_event(StreamingEndedEvent(message_id=message.id, completed_blocks=completed_blocks))
 
-            # Check if streaming has ended
-            if not self.is_streaming_active():
-                self._emit_event(StreamingEndedEvent(message_id=message.id, completed_blocks=completed_blocks))
+    def _mark_block_complete(self, message_id: str, block: MessageBlock) -> bool:
+        """Finalize a streaming block: flush buffered content, flip streaming flag,
+        emit BlockFullyAddedEvent. Idempotent; returns True iff the block transitioned."""
+        if not block.streaming:
+            return False
+        block.streaming = False
+        if block.id in self.streaming_content:
+            block.content = self.streaming_content[block.id]
+        self._emit_event(
+            BlockFullyAddedEvent(
+                block_id=block.id,
+                message_id=message_id,
+                block=self._copy_block_without_live_provider(block),
+            )
+        )
+        return True
 
     def complete_generation(self) -> None:
         """Mark the message as fully added and emit the event"""

--- a/packages/agent-sdk/spaik_sdk/thread/thread_container.py
+++ b/packages/agent-sdk/spaik_sdk/thread/thread_container.py
@@ -37,27 +37,22 @@ class ThreadContainer:
         self.streaming_content: Dict[str, str] = {}
         self.tool_call_responses: Dict[str, ToolCallResponse] = {}
         self.system_prompt = system_prompt
-        # Single event stream with multiple subscribers
         self._subscribers: List[Callable[[ThreadEvent], None]] = []
 
-        # Version tracking
         self._version = 0
         self._last_activity_time = int(time.time() * 1000)
         self.thread_id = str(uuid.uuid4())
         self.job_id = "unknown"
 
     def subscribe(self, callback: Callable[[ThreadEvent], None]) -> None:
-        """Subscribe to the event stream"""
         if callback not in self._subscribers:
             self._subscribers.append(callback)
 
     def unsubscribe(self, callback: Callable[[ThreadEvent], None]) -> None:
-        """Unsubscribe from the event stream"""
         if callback in self._subscribers:
             self._subscribers.remove(callback)
 
     def _emit_event(self, event: ThreadEvent) -> None:
-        """Emit a typed event to all subscribers"""
         for callback in self._subscribers:
             try:
                 callback(event)
@@ -65,69 +60,60 @@ class ThreadContainer:
                 logger.error(f"Event callback error: {e}")
 
     def _increment_version(self) -> None:
-        """Increment version and update activity time"""
         self._version += 1
         self._last_activity_time = int(time.time() * 1000)
 
     def get_version(self) -> int:
-        """Get current version for incremental updates"""
         return self._version
 
     def get_last_activity_time(self) -> int:
-        """Get timestamp of last activity"""
         return self._last_activity_time
 
     def add_streaming_message_chunk(self, block_id: str, content: str) -> None:
-        """Update streaming content by appending new content to existing content for the block_id"""
         if block_id in self.streaming_content:
             self.streaming_content[block_id] += content
         else:
             self.streaming_content[block_id] = content
 
-        # Emit streaming update event
         self._emit_event(StreamingUpdatedEvent(block_id=block_id, content=content, total_content=self.streaming_content[block_id]))
-
         self._increment_version()
 
     def add_message(self, msg: ThreadMessage) -> None:
-        """Add a new message to the thread"""
         self.messages.append(msg)
         self._emit_event(MessageAddedEvent(message=self._copy_message_without_live_providers(msg)))
         self._increment_version()
 
     def add_message_block(self, message_id: str, block: MessageBlock) -> None:
-        """Add a message block to an existing message by message_id"""
         for message in self.messages:
-            if message.id == message_id:
-                existing_block_index = next(
-                    (index for index, existing_block in enumerate(message.blocks) if existing_block.id == block.id), -1
-                )
-                is_new_block = existing_block_index == -1
-                if is_new_block:
-                    message.blocks.append(block)
-                else:
-                    existing_block = message.blocks[existing_block_index]
-                    if block.tool_call_response is None:
-                        block.tool_call_response = existing_block.tool_call_response
-                    if block.tool_call_error is None:
-                        block.tool_call_error = existing_block.tool_call_error
-                    message.blocks[existing_block_index] = block
+            if message.id != message_id:
+                continue
 
-                # Emit block added event
+            existing_block_index = next((index for index, existing_block in enumerate(message.blocks) if existing_block.id == block.id), -1)
+            is_new_block = existing_block_index == -1
+            if is_new_block:
+                message.blocks.append(block)
+            else:
+                existing_block = message.blocks[existing_block_index]
+                if block.tool_call_response is None:
+                    block.tool_call_response = existing_block.tool_call_response
+                if block.tool_call_error is None:
+                    block.tool_call_error = existing_block.tool_call_error
+                message.blocks[existing_block_index] = block
+
+            self._emit_event(BlockAddedEvent(message_id=message_id, block_id=block.id, block=self._copy_block_without_live_provider(block)))
+
+            if is_new_block and block.type == MessageBlockType.TOOL_USE and block.tool_call_id:
                 self._emit_event(
-                    BlockAddedEvent(message_id=message_id, block_id=block.id, block=self._copy_block_without_live_provider(block))
+                    ToolCallStartedEvent(
+                        tool_call_id=block.tool_call_id,
+                        tool_name=block.tool_name or "unknown",
+                        message_id=message_id,
+                        block_id=block.id,
+                    )
                 )
 
-                # If it's a tool block, emit tool call started
-                if is_new_block and block.type == MessageBlockType.TOOL_USE and block.tool_call_id:
-                    tool_name = block.tool_name or "unknown"
-
-                    self._emit_event(
-                        ToolCallStartedEvent(tool_call_id=block.tool_call_id, tool_name=tool_name, message_id=message_id, block_id=block.id)
-                    )
-
-                self._increment_version()
-                break
+            self._increment_version()
+            break
 
     def add_tool_call_response(self, response: ToolCallResponse) -> None:
         """Record a tool call response and finalize the matching tool-use block."""
@@ -161,7 +147,6 @@ class ThreadContainer:
         self.add_tool_call_response(ToolCallResponse(id=tool_call_id, response=response, error=error))
 
     def add_error_message(self, error_text: str, author_id: str = "system", author_name: str = "system") -> str:
-        """Add an error message and return the message ID"""
         message_id = str(uuid.uuid4())
         error_message = ThreadMessage(
             id=message_id,
@@ -229,13 +214,11 @@ class ThreadContainer:
         return True
 
     def complete_generation(self) -> None:
-        """Mark the message as fully added and emit the event"""
         latest_message = self.get_latest_ai_message()
         if latest_message:
             self._emit_event(MessageFullyAddedEvent(message=self._copy_message_without_live_providers(latest_message)))
 
     def is_streaming_active(self) -> bool:
-        """Check if any blocks are currently streaming"""
         for message in self.messages:
             for block in message.blocks:
                 if block.streaming:
@@ -243,37 +226,29 @@ class ThreadContainer:
         return False
 
     def get_latest_ai_message(self) -> Optional[ThreadMessage]:
-        """Get the most recent AI message"""
         for message in reversed(self.messages):
             if message.ai:
                 return message
         return None
 
     def get_latest_message(self) -> ThreadMessage:
-        """Get the most recent message"""
         return self.messages[-1]
 
     def get_message_by_id(self, message_id: str) -> Optional[ThreadMessage]:
-        """Get message by ID"""
         for message in self.messages:
             if message.id == message_id:
                 return message
         return None
 
     def get_block_content(self, block: MessageBlock) -> str:
-        """Get content for a specific block"""
-        # First check if block has content directly
         if block.content is not None:
             return block.content
 
-        # For streaming blocks, check streaming_content
         if block.id in self.streaming_content:
             return self.streaming_content[block.id]
 
-        if block.type == MessageBlockType.TOOL_USE:
-            if block.tool_call_id and block.tool_call_id in self.tool_call_responses:
-                response = self.tool_call_responses[block.tool_call_id]
-                return response.response
+        if block.type == MessageBlockType.TOOL_USE and block.tool_call_id and block.tool_call_id in self.tool_call_responses:
+            return self.tool_call_responses[block.tool_call_id].response
 
         return ""
 
@@ -283,44 +258,31 @@ class ThreadContainer:
         return self.system_prompt
 
     def get_streaming_blocks(self) -> List[str]:
-        """Get list of currently streaming block IDs"""
-        streaming_blocks = []
-        for message in self.messages:
-            for block in message.blocks:
-                if block.streaming:
-                    streaming_blocks.append(block.id)
-        return streaming_blocks
+        return [block.id for message in self.messages for block in message.blocks if block.streaming]
 
     def has_errors(self) -> bool:
-        """Check if there are any error blocks or tool errors"""
         for message in self.messages:
             for block in message.blocks:
                 if block.type == MessageBlockType.ERROR:
                     return True
 
-        for response in self.tool_call_responses.values():
-            if response.error:
-                return True
-
-        return False
+        return any(response.error for response in self.tool_call_responses.values())
 
     def get_final_text_content(self) -> str:
-        """Get clean final text from the latest AI message"""
         latest_message = self.get_latest_ai_message()
         if not latest_message:
             return ""
 
-        text_parts = []
+        text_parts: List[str] = []
         for block in latest_message.blocks:
-            if block.type == MessageBlockType.PLAIN and not block.streaming:
-                content = self.get_block_content(block)
-                if content:
-                    text_parts.append(content)
-
+            if block.type != MessageBlockType.PLAIN or block.streaming:
+                continue
+            content = self.get_block_content(block)
+            if content:
+                text_parts.append(content)
         return " ".join(text_parts).strip()
 
     def _find_message_id_by_block(self, block_id: str) -> Optional[str]:
-        """Find message ID that contains the given block ID"""
         for message in self.messages:
             for block in message.blocks:
                 if block.id == block_id:
@@ -328,9 +290,8 @@ class ThreadContainer:
         return None
 
     def get_langchain_messages(self) -> List[BaseMessage]:
-        """Get all messages as LangChain BaseMessages"""
         messages: List[BaseMessage] = [SystemMessage(content=self.get_system_prompt())]
-        messages.extend([convert_thread_message_to_langchain(msg) for msg in self.messages])
+        messages.extend(convert_thread_message_to_langchain(msg) for msg in self.messages)
         return messages
 
     async def get_langchain_messages_multimodal(
@@ -338,7 +299,6 @@ class ThreadContainer:
         file_storage: BaseFileStorage,
         provider_family: str = "openai",
     ) -> List[BaseMessage]:
-        """Get all messages as LangChain BaseMessages with multimodal content support"""
         messages: List[BaseMessage] = [SystemMessage(content=self.get_system_prompt())]
         for msg in self.messages:
             converted = await convert_thread_message_to_langchain_multimodal(
@@ -360,11 +320,9 @@ class ThreadContainer:
                 block.tool_provider = provider_by_id.get(block.tool_provider_id)
 
     def get_nof_messages_including_system(self) -> int:
-        """Get number of messages including system message"""
         return len(self.messages) + 1
 
     def add_consumption_metadata(self, message_id: str, consumption_metadata: TokenUsage) -> None:
-        """Add consumption metadata to a specific message"""
         for message in self.messages:
             if message.id == message_id:
                 message.consumption_metadata = consumption_metadata
@@ -372,7 +330,6 @@ class ThreadContainer:
                 break
 
     def get_total_consumption(self) -> TokenUsage:
-        """Calculate total consumption across all messages with consumption metadata"""
         total_tokens = TokenUsage()
 
         for message in self.messages:
@@ -388,21 +345,18 @@ class ThreadContainer:
         return total_tokens
 
     def get_consumption_by_message(self, message_id: str) -> Optional[TokenUsage]:
-        """Get consumption metadata for a specific message"""
         for message in self.messages:
             if message.id == message_id and message.consumption_metadata:
                 return message.consumption_metadata
         return None
 
     def get_latest_token_usage(self) -> Optional[TokenUsage]:
-        """Get consumption metadata for the latest message"""
         latest_message = self.get_latest_ai_message()
         if latest_message and latest_message.consumption_metadata:
             return latest_message.consumption_metadata
         return None
 
     def __str__(self) -> str:
-        """String representation of the entire thread container"""
         lines = ["=== THREAD CONTAINER ==="]
         lines.append(f"Version: {self._version} | Active streaming: {self.is_streaming_active()}")
 
@@ -421,7 +375,6 @@ class ThreadContainer:
                     stream_indicator = "✅"
                 tool_info = f" | tool_id: {block.tool_call_id}" if block.tool_call_id else ""
 
-                # Get content preview for the block
                 content = self.get_block_content(block)
                 content_preview = content[:50] + "..." if len(content) > 50 else content
                 content_info = f" | {repr(content_preview)}" if content else " (no content)"
@@ -441,7 +394,6 @@ class ThreadContainer:
             if response.error:
                 lines.append(f"    Error: {response.error}")
 
-        # Add consumption summary
         total_consumption = self.get_total_consumption()
         consumption_messages = sum(1 for msg in self.messages if msg.consumption_metadata)
         total_messages = len(self.messages)
@@ -462,15 +414,11 @@ class ThreadContainer:
         return "\n".join(lines)
 
     def print_all(self) -> None:
-        """Print everything to console for debugging"""
         print(str(self))
 
     def create_serializable_copy(self) -> "ThreadContainer":
-        """Create a copy of this ThreadContainer that can be safely pickled"""
-        # Create new instance without calling __init__ to avoid subscriber initialization
+        """Create a copy that can be safely pickled, with live providers and subscribers stripped."""
         thread_copy = ThreadContainer.__new__(ThreadContainer)
-
-        # Copy all serializable attributes
         thread_copy.messages = [self._copy_message_without_live_providers(message) for message in self.messages]
         thread_copy.streaming_content = self.streaming_content.copy()
         thread_copy.tool_call_responses = copy.deepcopy(self.tool_call_responses)
@@ -479,10 +427,7 @@ class ThreadContainer:
         thread_copy._last_activity_time = self._last_activity_time
         thread_copy.thread_id = self.thread_id
         thread_copy.job_id = self.job_id
-
-        # Initialize empty subscribers list (will be empty when loaded)
         thread_copy._subscribers = []
-
         return thread_copy
 
     def _copy_block_without_live_provider(self, block: MessageBlock) -> MessageBlock:

--- a/packages/agent-sdk/spaik_sdk/thread/thread_container.py
+++ b/packages/agent-sdk/spaik_sdk/thread/thread_container.py
@@ -116,7 +116,12 @@ class ThreadContainer:
             break
 
     def add_tool_call_response(self, response: ToolCallResponse) -> None:
-        """Record a tool call response and finalize the matching tool-use block."""
+        """Record a tool call response and finalize the matching tool-use block.
+
+        Always emits ToolResponseReceivedEvent. BlockFullyAddedEvent is emitted via
+        _mark_block_complete only on the streaming->done transition, so calling this
+        twice for the same tool_call_id emits the completion event at most once.
+        """
         self.tool_call_responses[response.id] = response
 
         target_message_id: Optional[str] = None

--- a/packages/agent-sdk/tests/unit/spaik_sdk/thread/test_thread_container.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/thread/test_thread_container.py
@@ -7,7 +7,16 @@ from unittest.mock import MagicMock
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
-from spaik_sdk.thread.models import BlockAddedEvent, BlockFullyAddedEvent, MessageAddedEvent, MessageBlock, MessageBlockType, ThreadMessage
+from spaik_sdk.thread.models import (
+    BlockAddedEvent,
+    BlockFullyAddedEvent,
+    MessageAddedEvent,
+    MessageBlock,
+    MessageBlockType,
+    ThreadMessage,
+    ToolCallResponse,
+    ToolResponseReceivedEvent,
+)
 from spaik_sdk.thread.thread_container import ThreadContainer
 from spaik_sdk.tools.tool_provider import BaseTool, ToolProvider
 
@@ -317,3 +326,58 @@ class TestThreadContainer:
 
         assert reloaded_block.tool_provider is rebound_provider
         assert reloaded_block.tool_provider is not original_provider
+
+    def test_add_tool_call_response_completes_the_tool_block_and_emits_block_fully_added_event(self):
+        thread = ThreadContainer(system_prompt="system prompt")
+        thread.add_message(make_message("message-1", True, MessageBlock(id="plain-1", streaming=False, type=MessageBlockType.PLAIN)))
+        thread.add_message_block(
+            "message-1",
+            MessageBlock(
+                id="tool-1",
+                streaming=True,
+                type=MessageBlockType.TOOL_USE,
+                tool_name="search",
+                tool_call_id="call-1",
+                tool_call_args={"q": "hi"},
+            ),
+        )
+
+        events: list[object] = []
+        thread.subscribe(events.append)
+
+        thread.add_tool_call_response(ToolCallResponse(id="call-1", response="hits: 3"))
+
+        tool_block = thread.messages[0].blocks[1]
+        assert tool_block.streaming is False
+        assert tool_block.tool_call_response == "hits: 3"
+
+        response_events = [event for event in events if isinstance(event, ToolResponseReceivedEvent)]
+        fully_added_events = [event for event in events if isinstance(event, BlockFullyAddedEvent) and event.block_id == "tool-1"]
+
+        assert len(response_events) == 1
+        assert len(fully_added_events) == 1
+        assert fully_added_events[0].block.tool_name == "search"
+        assert fully_added_events[0].block.tool_call_response == "hits: 3"
+        assert fully_added_events[0].block.streaming is False
+
+    def test_finalize_streaming_blocks_does_not_re_emit_for_already_completed_tool_block(self):
+        thread = ThreadContainer(system_prompt="system prompt")
+        thread.add_message(make_message("message-1", True, MessageBlock(id="plain-1", streaming=False, type=MessageBlockType.PLAIN)))
+        thread.add_message_block(
+            "message-1",
+            MessageBlock(
+                id="tool-1",
+                streaming=True,
+                type=MessageBlockType.TOOL_USE,
+                tool_name="search",
+                tool_call_id="call-1",
+            ),
+        )
+        thread.add_tool_call_response(ToolCallResponse(id="call-1", response="done"))
+
+        events: list[BlockFullyAddedEvent] = []
+        thread.subscribe(lambda event: events.append(event) if isinstance(event, BlockFullyAddedEvent) else None)
+
+        thread.finalize_streaming_blocks("message-1", ["tool-1"])
+
+        assert events == []

--- a/packages/agent-sdk/tests/unit/spaik_sdk/tracing/test_tracing.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/tracing/test_tracing.py
@@ -1,10 +1,20 @@
 """Unit tests for tracing module - NoOpTraceSink, configure_tracing, get_trace_sink resolution, agent instance ID."""
 
+import time
 import uuid
 from unittest.mock import MagicMock
 
 import pytest
 
+from spaik_sdk.thread.models import (
+    BlockFullyAddedEvent,
+    MessageBlock,
+    MessageBlockType,
+    ThreadEvent,
+    ThreadMessage,
+    ToolCallResponse,
+)
+from spaik_sdk.thread.thread_container import ThreadContainer
 from spaik_sdk.tracing import (
     AgentTrace,
     LocalTraceSink,
@@ -340,6 +350,46 @@ class TestAgentTrace:
         trace2 = AgentTrace(system_prompt="test2")
 
         assert trace1.agent_instance_id != trace2.agent_instance_id
+
+    def test_trace_records_tool_blocks_from_thread_container_lifecycle(self, clean_env):
+        """Tool calls must show up in traces via the standard BlockFullyAddedEvent flow."""
+        trace = AgentTrace(system_prompt="system prompt")
+        thread = ThreadContainer(system_prompt="system prompt")
+
+        def forward(event: ThreadEvent) -> None:
+            if isinstance(event, BlockFullyAddedEvent):
+                trace.add_block(event.block)
+
+        thread.subscribe(forward)
+
+        message_id = "message-1"
+        thread.add_message(
+            ThreadMessage(
+                id=message_id,
+                ai=True,
+                author_id="assistant",
+                author_name="assistant",
+                timestamp=int(time.time() * 1000),
+                blocks=[],
+            )
+        )
+        thread.add_message_block(
+            message_id,
+            MessageBlock(
+                id="tool-1",
+                streaming=True,
+                type=MessageBlockType.TOOL_USE,
+                tool_name="calculator",
+                tool_call_id="call-1",
+                tool_call_args={"expression": "2 + 2"},
+            ),
+        )
+        thread.add_tool_call_response(ToolCallResponse(id="call-1", response="4"))
+        thread.finalize_streaming_blocks(message_id, ["tool-1"])
+
+        rendered = trace.to_string(include_system_prompt=False)
+        assert "🔧: calculator" in rendered
+        assert '"expression": "2 + 2"' in rendered
 
 
 @pytest.mark.unit


### PR DESCRIPTION
# fix(thread): emit BlockFullyAddedEvent for tool-use blocks

## Problem

Local traces silently dropped every tool call. A run with three `calculator` invocations only showed reasoning and the final assistant message — no `🔧: calculator {...}` lines. This also affected any other `BlockFullyAddedEvent` subscriber, not just `AgentTrace`.

## Root cause

Four different call sites in `ThreadContainer` were independently responsible for the "block finishes streaming" transition, and they disagreed on the contract:

| Site | Flipped `streaming=False`? | Emitted `BlockFullyAddedEvent`? |
|---|---|---|
| `finalize_streaming_blocks` | yes (guarded on `streaming=True`) | yes |
| `add_tool_call_response` | yes (direct mutation) | **no** |
| `update_tool_use_block_with_response` | yes (redundant duplicate of the above) | no |
| `cancel_generation` | yes (direct mutation) | yes (but also for already-completed blocks) |

Because the tool-response path flipped the flag eagerly without emitting the event, the later `COMPLETE` → `finalize_streaming_blocks` saw `streaming=False` and skipped the block. The invariant "streaming → done = exactly one `BlockFullyAddedEvent`" was implicit and unenforced, which is why this regressed silently.

## Fix

Introduce a single private helper `_mark_block_complete(message_id, block)` that owns the transition — idempotent, flushes `streaming_content`, emits `BlockFullyAddedEvent` exactly once. Every call site now goes through it. `update_tool_use_block_with_response` collapses into a thin wrapper over `add_tool_call_response` since the extra mutation loop was pure duplication.

Second commit is a boyscout pass on the same file to strip narrative comments and thin docstrings, aligned with the repo's own style rules.

## Test plan

- [x] New unit: `add_tool_call_response` emits `BlockFullyAddedEvent` with response data on the block
- [x] New unit: `finalize_streaming_blocks` is idempotent for already-completed tool blocks (no double emit)
- [x] New unit: end-to-end — drive a tool-call lifecycle through `ThreadContainer` into an `AgentTrace` subscriber and assert `🔧: calculator {...}` shows up in the rendered trace
- [x] `make lint-fix && make typecheck && make test-unit` — 268 passed, 0 failed

## Scope / risk

- `thread_container.py` internal refactor, no public API changes beyond `update_tool_use_block_with_response` now delegating (same signature, same semantics)
- `BlockFullyAddedEvent` now fires for tool-use blocks for the first time. Any subscriber that previously relied on never receiving it for tool blocks would be affected — none found in repo (trace + UI hooks were already the intended consumers)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for tool-call response handling and validation.
  * Added end-to-end test for tool invocation tracing to ensure proper logging of tool usage.

* **Refactor**
  * Simplified internal thread management logic for improved maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->