### PR TITLE
docs: document recent SDK capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ agent-sdk/
 
 - `agent/base_agent.py` - Main agent class, handles prompts, tools, streaming
 - `models/model_registry.py` - LLM model definitions and aliases
-- `models/providers/` - Provider implementations (OpenAI, Anthropic, Google, Ollama)
-- `tools/tool_provider.py` - Tool definition system using LangChain
+- `models/providers/` - Provider implementations (OpenAI, Anthropic, Google, Azure AI Foundry, DeepSeek, Mistral, Meta Llama, Cohere, xAI, Moonshot, Ollama)
+- `tools/tool_provider.py` - Tool definition system using LangChain. Use `persist_tool_block_history=False` or override `render_tool_block_for_history()` to control how provider-owned tool calls replay into model history.
 - `thread/` - Conversation state, message blocks, event streaming
 - `server/api/routers/api_builder.py` - FastAPI router factory
 - `orchestration/base_orchestrator.py` - Code-first workflow orchestration
@@ -86,6 +86,8 @@ print(agent.get_response_text("What's the weather in Helsinki?"))
 - `get_event_stream(input)` - Async generator for ThreadEvents
 - `get_structured_response(prompt, Schema)` - Returns Pydantic model
 - `spawn(task)` - Run as isolated subagent (prevents LangChain callback leaks)
+- `get_langchain_model()` - Return the underlying LangChain chat model
+- `get_react_agent()` - Return a LangGraph ReAct agent wired with the agent's tools
 - `run_cli()` - Interactive CLI mode
 
 ### FastAPI Server
@@ -110,11 +112,14 @@ from spaik_sdk.models.model_registry import ModelRegistry
 
 # Direct access
 ModelRegistry.CLAUDE_4_SONNET
+ModelRegistry.CLAUDE_4_6_SONNET
 ModelRegistry.GPT_4_1
 ModelRegistry.GEMINI_2_5_FLASH
+ModelRegistry.DEEPSEEK_V3_2
+ModelRegistry.GROK_4
 
 # By alias
-ModelRegistry.from_name("sonnet")      # CLAUDE_4_SONNET
+ModelRegistry.from_name("sonnet")      # CLAUDE_4_6_SONNET
 ModelRegistry.from_name("gpt 4.1")     # GPT_4_1
 ModelRegistry.from_name("opus 4.5")    # CLAUDE_4_5_OPUS
 ```
@@ -198,7 +203,7 @@ bun run dev:backend            # Start example backend
 ## Environment Variables
 
 ```bash
-# LLM Providers (at least one required)
+# Direct mode: at least one LLM provider API key required
 ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-...
 GOOGLE_API_KEY=...
@@ -207,6 +212,12 @@ GOOGLE_API_KEY=...
 AZURE_API_KEY=...
 AZURE_ENDPOINT=https://your-resource.openai.azure.com/
 DEFAULT_MODEL=claude-sonnet-4-20250514
+
+# Proxy mode for centralized LLM routing
+LLM_AUTH_MODE=proxy
+LLM_PROXY_BASE_URL=https://llm-proxy.example.com
+LLM_PROXY_API_KEY=proxy-key
+LLM_PROXY_HEADERS=X-Team:Agents,X-App:Demo
 ```
 
 ## API Endpoints
@@ -236,4 +247,4 @@ Python tests use pytest with recorded LLM responses for determinism:
 
 ## License
 
-MIT - Copyright (c) 2025 Siili Solutions Oyj
+MIT - Copyright (c) 2026 Siili Solutions Oyj

--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ Siili Solutions Oyj assumes no liability for the use of this software.
 ## Features
 
 **Python SDK**
-- Multi-provider support: OpenAI, Anthropic, Google, Azure, Ollama
+- Multi-provider support: OpenAI, Anthropic, Google, Azure AI Foundry, DeepSeek, Mistral, Meta Llama, Cohere, xAI (Grok), Moonshot (Kimi), Ollama
 - Unified API across all providers
 - Streaming responses with SSE
 - Tool/function calling with LangChain
+- Isolated subagents with `spawn()`
+- Configurable trace persistence
 - Structured outputs via Pydantic
 - FastAPI server with thread persistence
 - File attachments and audio (TTS/STT)
@@ -41,9 +43,10 @@ Siili Solutions Oyj assumes no liability for the use of this software.
 | Package | Description | npm/PyPI |
 |---------|-------------|----------|
 | `spaik-sdk` | Python SDK | [PyPI](https://pypi.org/project/spaik-sdk/) |
-| `spaik-sdk-react` | React hooks | npm |
-| `spaik-sdk-material` | Material UI components | npm |
+| `spaik-sdk-react` | React hooks | [npm](https://www.npmjs.com/package/spaik-sdk-react) |
+| `spaik-sdk-material` | Material UI components | [npm](https://www.npmjs.com/package/spaik-sdk-material) |
 | `spaik-coding-agents` | Pre-built coding agents | [PyPI](https://pypi.org/project/spaik-coding-agents/) |
+| `spaik-agent-workflows` | YAML-driven workflow engine | [PyPI](https://pypi.org/project/spaik-agent-workflows/) |
 
 ## Quick Start
 
@@ -79,6 +82,21 @@ class MyAgent(BaseAgent):
 
 agent = MyAgent(system_prompt="You can search for information.")
 print(agent.get_response_text("Search for Python tutorials"))
+```
+
+### Subagents
+
+Use `spawn()` when one agent calls another agent from inside a tool. It runs the subagent in an isolated context so the subagent's internal tool calls do not leak into the parent thread.
+
+```python
+class ResearchTools(ToolProvider):
+    def get_tools(self) -> list[BaseTool]:
+        @tool
+        def research(topic: str) -> str:
+            """Delegate a research task to a specialist subagent."""
+            sub = ResearchAgent(system_prompt="You are a research specialist.")
+            return sub.spawn(topic).get_text_content()
+        return [research]
 ```
 
 ### FastAPI Server
@@ -187,7 +205,7 @@ Open `http://localhost:5173`
 ## Environment Variables
 
 ```bash
-# At least one LLM provider API key required
+# Direct mode: at least one LLM provider API key required
 ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-...
 GOOGLE_API_KEY=...
@@ -196,6 +214,17 @@ GOOGLE_API_KEY=...
 AZURE_API_KEY=...
 AZURE_ENDPOINT=https://your-resource.openai.azure.com/
 DEFAULT_MODEL=claude-sonnet-4-20250514
+```
+
+### Proxy Mode
+
+Set `LLM_AUTH_MODE=proxy` to route all provider traffic through one LLM proxy endpoint, such as LiteLLM or an internal gateway.
+
+```bash
+LLM_AUTH_MODE=proxy
+LLM_PROXY_BASE_URL=https://llm-proxy.example.com
+LLM_PROXY_API_KEY=proxy-key
+LLM_PROXY_HEADERS=X-Team:Agents,X-App:Demo
 ```
 
 ## Model Support
@@ -208,25 +237,40 @@ ModelRegistry.CLAUDE_4_SONNET
 ModelRegistry.CLAUDE_4_OPUS
 ModelRegistry.CLAUDE_4_5_SONNET
 ModelRegistry.CLAUDE_4_5_OPUS
+ModelRegistry.CLAUDE_4_6_SONNET
+ModelRegistry.CLAUDE_4_6_OPUS
 
 # OpenAI
 ModelRegistry.GPT_4_1
 ModelRegistry.GPT_4O
 ModelRegistry.O4_MINI
+ModelRegistry.GPT_5_4
 
 # Google
 ModelRegistry.GEMINI_2_5_FLASH
 ModelRegistry.GEMINI_2_5_PRO
+ModelRegistry.GEMINI_3_1_PRO
+
+# Azure AI Foundry and other provider families
+ModelRegistry.DEEPSEEK_V3_2
+ModelRegistry.MISTRAL_LARGE_3
+ModelRegistry.LLAMA_4_MAVERICK
+ModelRegistry.COHERE_COMMAND_A
+ModelRegistry.GROK_4
+ModelRegistry.KIMI_K2_THINKING
 
 # Aliases
-ModelRegistry.from_name("sonnet")  # -> CLAUDE_4_SONNET
-ModelRegistry.from_name("opus")    # -> CLAUDE_4_5_OPUS
+ModelRegistry.from_name("sonnet")  # -> CLAUDE_4_6_SONNET
+ModelRegistry.from_name("opus")    # -> CLAUDE_4_6_OPUS
 ```
 
 ## Documentation
 
 - [Python SDK](packages/agent-sdk/README.md)
 - [React Hooks](packages/agent-sdk-hooks/README.md)
+- [Material UI Components](packages/agent-sdk-material/README.md)
+- [Agent Workflows](packages/agent-workflows/README.md)
+- [Coding Agents](packages/coding-agents/README.md)
 - [Examples](examples/)
 
 ## Development
@@ -246,7 +290,7 @@ bun run build:material
 
 ## License
 
-MIT - Copyright (c) 2025 Siili Solutions Oyj
+MIT - Copyright (c) 2026 Siili Solutions Oyj
 
 ## Security and Compliance Notice
 

--- a/packages/agent-sdk-hooks/README.md
+++ b/packages/agent-sdk-hooks/README.md
@@ -287,7 +287,7 @@ function Chat({ threadId }) {
 SSE events handled:
 - `streaming_updated` - Content delta
 - `block_added` - New block started
-- `block_fully_added` - Block completed
+- `block_fully_added` - Block completed, including `tool_use` blocks
 - `message_fully_added` - Message completed
 - `tool_response_received` - Tool result
 

--- a/packages/agent-sdk/.cursor/rules/repo_overview.mdc
+++ b/packages/agent-sdk/.cursor/rules/repo_overview.mdc
@@ -29,7 +29,7 @@ This is a Python-based Agent SDK for building various kinds of agentic + AI solu
 
 #### **LLM Integration** (`app/models/`)
 Multi-provider LLM support with factory pattern:
-- **Supported Providers**: Anthropic (Claude), OpenAI (GPT), Google (Gemini), Azure AI Foundry
+- **Supported Providers**: Anthropic (Claude), OpenAI (GPT), Google (Gemini), Azure AI Foundry, DeepSeek, Mistral, Meta Llama, Cohere, xAI (Grok), Moonshot (Kimi), Ollama
 - **[app/models/llm_types.py](mdc:app/models/llm_types.py)** - Model enums and provider types
 - **[app/models/llm_config.py](mdc:app/models/llm_config.py)** - LLM configuration dataclass
 - **[app/models/factories/](mdc:app/models/factories)** - Model factory implementations per provider
@@ -48,11 +48,13 @@ Multi-provider LLM support with factory pattern:
 #### **Tool System** (`app/tools/`)
 - **[app/tools/tool_provider.py](mdc:app/tools/tool_provider.py)** - Abstract base for creating agent tools
 - Supports LangChain BaseTool integration with Pydantic schemas
+- Tool providers own their replay policy through `persist_tool_block_history`, `get_provider_id()`, and `render_tool_block_for_history()`
 
 #### **Configuration & Infrastructure**
 - **[config/env.py](mdc:config/env.py)** - Environment variable management
 - **[app/prompt/prompt_loader.py](mdc:app/prompt/prompt_loader.py)** - Static prompt loading from markdown
 - **[app/tracing/agent_trace.py](mdc:app/tracing/agent_trace.py)** - Execution tracing for debugging
+- **[app/tracing/trace_sink.py](mdc:app/tracing/trace_sink.py)** - Pluggable trace persistence for local, noop, or custom sinks
 - **[app/utils/init_logger.py](mdc:app/utils/init_logger.py)** - Logging utilities
 
 ## Key Technologies & Dependencies

--- a/packages/agent-sdk/.cursor/rules/repo_overview.mdc
+++ b/packages/agent-sdk/.cursor/rules/repo_overview.mdc
@@ -54,7 +54,7 @@ Multi-provider LLM support with factory pattern:
 - **[config/env.py](mdc:config/env.py)** - Environment variable management
 - **[app/prompt/prompt_loader.py](mdc:app/prompt/prompt_loader.py)** - Static prompt loading from markdown
 - **[app/tracing/agent_trace.py](mdc:app/tracing/agent_trace.py)** - Execution tracing for debugging
-- **[app/tracing/trace_sink.py](mdc:app/tracing/trace_sink.py)** - Pluggable trace persistence for local, noop, or custom sinks
+- **[spaik_sdk/tracing/trace_sink.py](mdc:spaik_sdk/tracing/trace_sink.py)** - Pluggable trace persistence for local, noop, or custom sinks
 - **[app/utils/init_logger.py](mdc:app/utils/init_logger.py)** - Logging utilities
 
 ## Key Technologies & Dependencies

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -24,10 +24,12 @@ print(agent.get_response_text("Hello!"))
 
 ## Features
 
-- **Multi-LLM Support**: OpenAI, Anthropic, Google, Azure, Ollama
+- **Multi-LLM Support**: OpenAI, Anthropic, Google, Azure AI Foundry, DeepSeek, Mistral, Meta Llama, Cohere, xAI (Grok), Moonshot (Kimi), Ollama
 - **Unified API**: Same interface across all providers
 - **Streaming**: Real-time response streaming via SSE
 - **Tools**: Function calling with LangChain integration
+- **Subagents**: Isolated nested agent execution with `spawn()`
+- **Tracing**: Configurable trace persistence with pluggable sinks
 - **Structured Output**: Pydantic model responses
 - **Server**: FastAPI with thread persistence, auth, file uploads
 - **Audio**: Text-to-speech and speech-to-text
@@ -90,6 +92,17 @@ print(recipe.name)
 agent.run_cli()  # Starts interactive chat in terminal
 ```
 
+### LangGraph Interop
+
+Expose the configured LangChain model and a ready-to-use LangGraph ReAct agent when you need to compose Spaik agents into custom LangChain or LangGraph workflows.
+
+```python
+agent = MyAgent(system_prompt="You are helpful.")
+
+llm = agent.get_langchain_model()
+react_agent = agent.get_react_agent()
+```
+
 ## Tools
 
 ```python
@@ -131,6 +144,33 @@ class MyAgent(BaseAgent):
         ]
 ```
 
+### Controlling Tool-Call Replay in History
+
+Each `ToolProvider` controls how its tool-use blocks are rendered back into model history when a thread is replayed. By default, the replay contains the tool name, call id, arguments, response, and error state.
+
+Use `persist_tool_block_history=False` when a provider should replay only a name marker instead of full call details. This is useful for tools whose output is large, sensitive, or not useful to show the model again.
+
+```python
+class SearchTools(ToolProvider):
+    def __init__(self) -> None:
+        super().__init__(persist_tool_block_history=False)
+
+    def get_tools(self) -> list[BaseTool]:
+        ...
+```
+
+Override `render_tool_block_for_history()` when you need provider-specific history text.
+
+```python
+from spaik_sdk.thread.models import MessageBlock
+
+class SearchTools(ToolProvider):
+    def render_tool_block_for_history(self, block: MessageBlock) -> str:
+        return f'<search tool="{block.tool_name}" />'
+```
+
+Tool-use blocks persist the owning provider id on the thread, so after a thread reload the SDK rebinds the correct `ToolProvider` and applies the same history-rendering policy. Override `get_provider_id()` if a provider needs a stable id across package or class renames.
+
 ## Subagents
 
 To call one agent from inside another agent's tool, use `spawn()` instead of `get_response()`. This prevents LangChain's callback context from leaking into the subagent, which would otherwise cause the subagent's internal tool calls to appear in the parent thread.
@@ -148,6 +188,23 @@ class ResearchTools(ToolProvider):
 
 For cases where you need to isolate an arbitrary coroutine rather than a full agent call, use the static `BaseAgent.run_isolated(coro)` helper directly.
 
+## Tracing
+
+Every agent run produces an `AgentTrace`. Configure trace persistence with the `trace_sink` constructor argument or the `TRACE_SINK_MODE` environment variable.
+
+```python
+from spaik_sdk.tracing.local_trace_sink import LocalTraceSink
+from spaik_sdk.tracing.noop_trace_sink import NoOpTraceSink
+
+# Disable trace persistence
+agent = MyAgent(system_prompt="...", trace_sink=NoOpTraceSink())
+
+# Write traces to a custom directory
+agent = MyAgent(system_prompt="...", trace_sink=LocalTraceSink(traces_dir="./custom-traces"))
+```
+
+`TRACE_SINK_MODE=local` forces local file traces and `TRACE_SINK_MODE=noop` disables trace persistence. Implement `TraceSink` for remote or database-backed trace storage.
+
 ## Models
 
 ```python
@@ -158,18 +215,30 @@ ModelRegistry.CLAUDE_4_SONNET
 ModelRegistry.CLAUDE_4_OPUS
 ModelRegistry.CLAUDE_4_5_SONNET
 ModelRegistry.CLAUDE_4_5_OPUS
+ModelRegistry.CLAUDE_4_6_SONNET
+ModelRegistry.CLAUDE_4_6_OPUS
 
 # OpenAI
 ModelRegistry.GPT_4_1
 ModelRegistry.GPT_4O
 ModelRegistry.O4_MINI
+ModelRegistry.GPT_5_4
 
 # Google
 ModelRegistry.GEMINI_2_5_FLASH
 ModelRegistry.GEMINI_2_5_PRO
+ModelRegistry.GEMINI_3_1_PRO
+
+# Azure AI Foundry and other provider families
+ModelRegistry.DEEPSEEK_V3_2
+ModelRegistry.MISTRAL_LARGE_3
+ModelRegistry.LLAMA_4_MAVERICK
+ModelRegistry.COHERE_COMMAND_A
+ModelRegistry.GROK_4
+ModelRegistry.KIMI_K2_THINKING
 
 # Aliases
-ModelRegistry.from_name("sonnet")      # CLAUDE_4_SONNET
+ModelRegistry.from_name("sonnet")      # CLAUDE_4_6_SONNET
 ModelRegistry.from_name("gpt 4.1")     # GPT_4_1
 ModelRegistry.from_name("gemini 2.5")  # GEMINI_2_5_FLASH
 
@@ -248,6 +317,8 @@ api_builder = ApiBuilder.stateful(
 )
 ```
 
+Long-running streams are checkpointed incrementally. The built-in response generator calls `update_thread` after each `ToolResponseReceivedEvent` and `MessageFullyAddedEvent`, so completed tool results and messages survive crashes or restarts during a run.
+
 ## Orchestration
 
 Code-first workflow orchestration without graph DSLs:
@@ -298,7 +369,7 @@ result = orchestrator.run_sync()
 Environment variables:
 
 ```bash
-# LLM Providers (at least one required)
+# Direct mode: at least one LLM provider API key required
 ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-...
 GOOGLE_API_KEY=...
@@ -308,6 +379,17 @@ AZURE_API_KEY=...
 AZURE_ENDPOINT=https://your-resource.openai.azure.com/
 DEFAULT_MODEL=claude-sonnet-4-20250514
 ```
+
+### Proxy Mode
+
+Set `LLM_AUTH_MODE=proxy` to route every provider through a single proxy endpoint such as LiteLLM or an internal gateway. Provider API keys are not required in this mode.
+
+| Env Variable | Description |
+|--------------|-------------|
+| `LLM_AUTH_MODE` | `direct` (default) or `proxy` |
+| `LLM_PROXY_BASE_URL` | Proxy endpoint URL |
+| `LLM_PROXY_API_KEY` | Auth key sent to the proxy |
+| `LLM_PROXY_HEADERS` | Extra headers, comma-separated `Key:Value` pairs |
 
 ## Development
 

--- a/packages/agent-workflows/README.md
+++ b/packages/agent-workflows/README.md
@@ -8,10 +8,10 @@ Spaik SDK is an open-source project developed by engineers at Siili Solutions Oy
 
 ```bash
 # Install globally with uvx (recommended)
-uvx siili-agent-workflows --help
+uvx spaik-agent-workflows --help
 
 # Or install with pip
-pip install siili-agent-workflows
+pip install spaik-agent-workflows
 
 # Or install locally for development
 cd packages/agent-workflows
@@ -22,16 +22,16 @@ uv sync
 
 ```bash
 # Run a workflow by name
-siili-agent-workflows my-workflow --param value
+spaik-agent-workflows my-workflow --param value
 
 # List all available workflows
-siili-agent-workflows --list
+spaik-agent-workflows --list
 
 # Validate a workflow without running
-siili-agent-workflows my-workflow --validate
+spaik-agent-workflows my-workflow --validate
 
 # Show help
-siili-agent-workflows --help
+spaik-agent-workflows --help
 ```
 
 ## Workflow Discovery
@@ -40,7 +40,7 @@ Workflows are discovered from multiple locations (in order):
 
 1. **Current directory**: `./workflow-name.yml`, `./workflow-name.yaml`, etc.
 2. **Local workflows dir**: `./.agent_workflows/workflow-name.yml`
-3. **Global config**: `~/.config/siili-agent-workflows/workflow-name.yml`
+3. **Global config**: `~/.config/spaik-agent-workflows/workflow-name.yml`
 4. **Bundled**: Workflows shipped with the package
 
 Supported extensions: `.yml`, `.yaml`, `.agent-workflow.yml`, `.agent-workflow.yaml`
@@ -49,7 +49,7 @@ Supported extensions: `.yml`, `.yaml`, `.agent-workflow.yml`, `.agent-workflow.y
 
 Environment files are loaded in order (later overrides earlier):
 
-1. `~/.config/siili-agent-workflows/.env` (global)
+1. `~/.config/spaik-agent-workflows/.env` (global)
 2. `./.env` (current directory)
 3. `--env-file <path>` (explicit)
 
@@ -103,7 +103,7 @@ jobs:
 You can also pass variables as positional args:
 
 ```bash
-siili-agent-workflows apply-template --template agent --path ./my-agent
+spaik-agent-workflows apply-template --template agent --path ./my-agent
 ```
 
 ## Built-in Plugins

--- a/packages/agent-workflows/README.md
+++ b/packages/agent-workflows/README.md
@@ -8,10 +8,10 @@ Spaik SDK is an open-source project developed by engineers at Siili Solutions Oy
 
 ```bash
 # Install globally with uvx (recommended)
-uvx spaik-agent-workflows --help
+uvx siili-agent-workflows --help
 
 # Or install with pip
-pip install spaik-agent-workflows
+pip install siili-agent-workflows
 
 # Or install locally for development
 cd packages/agent-workflows
@@ -22,16 +22,16 @@ uv sync
 
 ```bash
 # Run a workflow by name
-spaik-agent-workflows my-workflow --param value
+siili-agent-workflows my-workflow --param value
 
 # List all available workflows
-spaik-agent-workflows --list
+siili-agent-workflows --list
 
 # Validate a workflow without running
-spaik-agent-workflows my-workflow --validate
+siili-agent-workflows my-workflow --validate
 
 # Show help
-spaik-agent-workflows --help
+siili-agent-workflows --help
 ```
 
 ## Workflow Discovery
@@ -40,7 +40,7 @@ Workflows are discovered from multiple locations (in order):
 
 1. **Current directory**: `./workflow-name.yml`, `./workflow-name.yaml`, etc.
 2. **Local workflows dir**: `./.agent_workflows/workflow-name.yml`
-3. **Global config**: `~/.config/spaik-agent-workflows/workflow-name.yml`
+3. **Global config**: `~/.config/siili-agent-workflows/workflow-name.yml`
 4. **Bundled**: Workflows shipped with the package
 
 Supported extensions: `.yml`, `.yaml`, `.agent-workflow.yml`, `.agent-workflow.yaml`
@@ -49,7 +49,7 @@ Supported extensions: `.yml`, `.yaml`, `.agent-workflow.yml`, `.agent-workflow.y
 
 Environment files are loaded in order (later overrides earlier):
 
-1. `~/.config/spaik-agent-workflows/.env` (global)
+1. `~/.config/siili-agent-workflows/.env` (global)
 2. `./.env` (current directory)
 3. `--env-file <path>` (explicit)
 
@@ -103,7 +103,7 @@ jobs:
 You can also pass variables as positional args:
 
 ```bash
-spaik-agent-workflows apply-template --template agent --path ./my-agent
+siili-agent-workflows apply-template --template agent --path ./my-agent
 ```
 
 ## Built-in Plugins

--- a/packages/agent-workflows/pyproject.toml
+++ b/packages/agent-workflows/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.21.1",
     "ruff",
-    "ty",
+    "ty==0.0.13",
 ]
 
 [project.urls]

--- a/packages/coding-agents/README.md
+++ b/packages/coding-agents/README.md
@@ -1,4 +1,4 @@
-# Siili Coding Agents
+# Spaik Coding Agents
 
 Pre-built coding agents for AI-assisted software development.
 


### PR DESCRIPTION
## Summary
- Document recent Python SDK features: provider-owned tool replay, subagents, LangGraph interop, trace sinks, incremental stream checkpointing, and proxy mode.
- Refresh provider/model examples and package links across root and package READMEs.
- Update internal agent guidance and package README naming for the Spaik package rename.

## Test plan
- `git diff --check -- README.md packages/agent-sdk/README.md packages/agent-sdk-hooks/README.md AGENTS.md packages/agent-sdk/.cursor/rules/repo_overview.mdc packages/agent-workflows/README.md packages/coding-agents/README.md`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded LLM provider support documentation across SDKs (added Azure, DeepSeek, Mistral, Meta Llama, Cohere, xAI/Grok, Moonshot/Kimi, Ollama).
  * Documented new subagent isolation capability via `spawn()`.
  * Added proxy mode configuration guidance for LLM routing alongside direct mode.
  * Updated tool-history replay control and tracing/persistence options.
  * Updated package branding references across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->