### PR TITLE
fix(agent-sdk): make max agent steps configurable

### DIFF
--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -117,7 +117,7 @@ agent = WeatherAgent(system_prompt="You provide weather info.")
 print(agent.get_response_text("What's the weather in Tokyo?"))
 ```
 
-For unusually long LangGraph tool loops, set `LLMConfig.langgraph_recursion_limit` above the default `100`.
+For unusually long tool loops, set `LLMConfig.max_agent_steps` above the default `100`.
 
 ### Built-in Tool Providers
 

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -117,6 +117,8 @@ agent = WeatherAgent(system_prompt="You provide weather info.")
 print(agent.get_response_text("What's the weather in Tokyo?"))
 ```
 
+For unusually long LangGraph tool loops, set `LLMConfig.langgraph_recursion_limit` above the default `100`.
+
 ### Built-in Tool Providers
 
 ```python

--- a/packages/agent-sdk/spaik_sdk/llm/langchain_service.py
+++ b/packages/agent-sdk/spaik_sdk/llm/langchain_service.py
@@ -196,7 +196,7 @@ class LangChainService:
             messages = self.thread_container.get_langchain_messages()
 
         # Use astream_events to get individual token events
-        config = RunnableConfig(recursion_limit=self.llm_config.langgraph_recursion_limit)
+        config = RunnableConfig(recursion_limit=self.llm_config.max_agent_steps)
         agent_stream = agent.astream_events({"messages": messages}, version="v2", config=config)
 
         # Let MessageHandler handle the token stream processing

--- a/packages/agent-sdk/spaik_sdk/llm/langchain_service.py
+++ b/packages/agent-sdk/spaik_sdk/llm/langchain_service.py
@@ -42,8 +42,6 @@ if DEBUG:
 
     set_debug(True)
 
-config = RunnableConfig(recursion_limit=100)
-
 T = TypeVar("T", bound=BaseModel)
 
 
@@ -198,6 +196,7 @@ class LangChainService:
             messages = self.thread_container.get_langchain_messages()
 
         # Use astream_events to get individual token events
+        config = RunnableConfig(recursion_limit=self.llm_config.langgraph_recursion_limit)
         agent_stream = agent.astream_events({"messages": messages}, version="v2", config=config)
 
         # Let MessageHandler handle the token stream processing

--- a/packages/agent-sdk/spaik_sdk/models/llm_config.py
+++ b/packages/agent-sdk/spaik_sdk/models/llm_config.py
@@ -18,6 +18,7 @@ class LLMConfig:
     reasoning_effort: str = "medium"  # Options: "low", "medium", "high"
     max_output_tokens: Optional[int] = None
     reasoning_budget_tokens: int = 4096
+    langgraph_recursion_limit: int = 100
     temperature: float = 0.1
     structured_response: bool = False
 

--- a/packages/agent-sdk/spaik_sdk/models/llm_config.py
+++ b/packages/agent-sdk/spaik_sdk/models/llm_config.py
@@ -18,7 +18,7 @@ class LLMConfig:
     reasoning_effort: str = "medium"  # Options: "low", "medium", "high"
     max_output_tokens: Optional[int] = None
     reasoning_budget_tokens: int = 4096
-    langgraph_recursion_limit: int = 100
+    max_agent_steps: int = 100
     temperature: float = 0.1
     structured_response: bool = False
 

--- a/packages/agent-sdk/tests/unit/spaik_sdk/llm/test_langchain_service_error.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/llm/test_langchain_service_error.py
@@ -96,10 +96,10 @@ class TestLangChainServiceErrorHandling:
                 assert events[0].error_type == "unknown"
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("recursion_limit", [3, 401])
-    async def test_execute_stream_tokens_passes_configured_langgraph_recursion_limit(self, recursion_limit: int):
+    @pytest.mark.parametrize("max_agent_steps", [3, 401])
+    async def test_execute_stream_tokens_passes_configured_max_agent_steps(self, max_agent_steps: int):
         service = make_service_with_mocks()
-        service.llm_config.langgraph_recursion_limit = recursion_limit
+        service.llm_config.max_agent_steps = max_agent_steps
 
         captured_config: RunnableConfig | None = None
         fake_agent = MagicMock()
@@ -128,4 +128,4 @@ class TestLangChainServiceErrorHandling:
 
         assert events == []
         assert captured_config is not None
-        assert captured_config["recursion_limit"] == recursion_limit
+        assert captured_config["recursion_limit"] == max_agent_steps

--- a/packages/agent-sdk/tests/unit/spaik_sdk/llm/test_langchain_service_error.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/llm/test_langchain_service_error.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
 from spaik_sdk.llm.langchain_service import LangChainService
@@ -93,3 +94,38 @@ class TestLangChainServiceErrorHandling:
                     events.append(event)
 
                 assert events[0].error_type == "unknown"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("recursion_limit", [3, 401])
+    async def test_execute_stream_tokens_passes_configured_langgraph_recursion_limit(self, recursion_limit: int):
+        service = make_service_with_mocks()
+        service.llm_config.langgraph_recursion_limit = recursion_limit
+
+        captured_config: RunnableConfig | None = None
+        fake_agent = MagicMock()
+
+        async def empty_agent_stream():
+            if False:
+                yield None
+
+        def fake_astream_events(_input, *, version: str, config: RunnableConfig):
+            nonlocal captured_config
+            assert version == "v2"
+            captured_config = config
+            return empty_agent_stream()
+
+        async def fake_process_stream(_agent_stream):
+            if False:
+                yield None
+
+        fake_agent.astream_events.side_effect = fake_astream_events
+        service.create_executor = MagicMock(return_value=fake_agent)  # type: ignore[method-assign]
+        service.message_handler.process_agent_token_stream = fake_process_stream  # type: ignore[method-assign]
+
+        with patch("spaik_sdk.llm.langchain_service.get_file_storage", return_value=None):
+            with patch.object(service.thread_container, "get_langchain_messages", return_value=[]):
+                events = [event async for event in service._execute_stream_tokens_direct(tools=[])]
+
+        assert events == []
+        assert captured_config is not None
+        assert captured_config["recursion_limit"] == recursion_limit


### PR DESCRIPTION
## Summary
- Add `LLMConfig.max_agent_steps` with the current default of `100`.
- Pass the configured step budget into LangGraph streamed execution instead of using a module-level hardcoded config.
- Document the setting briefly for long tool loops.

## Test plan
- `uv run python3 -m pytest tests/unit/spaik_sdk/llm/test_langchain_service_error.py tests/unit/spaik_sdk/llm/test_langchain_service_tool_errors.py --no-cov`
- `uv run ruff check spaik_sdk/llm/langchain_service.py spaik_sdk/models/llm_config.py tests/unit/spaik_sdk/llm/test_langchain_service_error.py`
- `uv run ty check spaik_sdk/llm/langchain_service.py spaik_sdk/models/llm_config.py tests/unit/spaik_sdk/llm/test_langchain_service_error.py`
- Manual uncommitted experiment: Spaik OpenAI agent completed 200 sequential tool calls with `max_agent_steps=500`.