### PR TITLE
Update built-in model registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,9 @@ from spaik_sdk.models.model_registry import ModelRegistry
 # Direct access
 ModelRegistry.CLAUDE_4_SONNET
 ModelRegistry.CLAUDE_4_6_SONNET
+ModelRegistry.CLAUDE_4_7_OPUS
 ModelRegistry.GPT_4_1
+ModelRegistry.GPT_5_5
 ModelRegistry.GEMINI_2_5_FLASH
 ModelRegistry.DEEPSEEK_V3_2
 ModelRegistry.GROK_4
@@ -121,7 +123,7 @@ ModelRegistry.GROK_4
 # By alias
 ModelRegistry.from_name("sonnet")      # CLAUDE_4_6_SONNET
 ModelRegistry.from_name("gpt 4.1")     # GPT_4_1
-ModelRegistry.from_name("opus 4.5")    # CLAUDE_4_5_OPUS
+ModelRegistry.from_name("opus")        # CLAUDE_4_7_OPUS
 ```
 
 ## React Hooks (packages/agent-sdk-hooks/)

--- a/README.md
+++ b/README.md
@@ -239,12 +239,15 @@ ModelRegistry.CLAUDE_4_5_SONNET
 ModelRegistry.CLAUDE_4_5_OPUS
 ModelRegistry.CLAUDE_4_6_SONNET
 ModelRegistry.CLAUDE_4_6_OPUS
+ModelRegistry.CLAUDE_4_7_OPUS
 
 # OpenAI
 ModelRegistry.GPT_4_1
 ModelRegistry.GPT_4O
 ModelRegistry.O4_MINI
 ModelRegistry.GPT_5_4
+ModelRegistry.GPT_5_4_NANO
+ModelRegistry.GPT_5_5
 
 # Google
 ModelRegistry.GEMINI_2_5_FLASH
@@ -261,7 +264,7 @@ ModelRegistry.KIMI_K2_THINKING
 
 # Aliases
 ModelRegistry.from_name("sonnet")  # -> CLAUDE_4_6_SONNET
-ModelRegistry.from_name("opus")    # -> CLAUDE_4_6_OPUS
+ModelRegistry.from_name("opus")    # -> CLAUDE_4_7_OPUS
 ```
 
 ## Documentation

--- a/packages/agent-sdk/.cursor/rules/model-update.mdc
+++ b/packages/agent-sdk/.cursor/rules/model-update.mdc
@@ -188,7 +188,7 @@ If adding a model from a brand new provider:
 
 ---
 
-## 6. MODELS IN REGISTRY (last updated 2026-03-02)
+## 6. MODELS IN REGISTRY (last updated 2026-04-29)
 
 This section is a snapshot — update it whenever you run a model update pass.
 
@@ -206,8 +206,9 @@ This section is a snapshot — update it whenever you run a model update pass.
 | `CLAUDE_4_5_OPUS` | `claude-opus-4-5-20251101` | Yes | |
 | `CLAUDE_4_6_OPUS` | `claude-opus-4-6` | Yes | $5/$25/MTok. 128K max output. |
 | `CLAUDE_4_6_SONNET` | `claude-sonnet-4-6` | Yes | $3/$15/MTok. 64K max output. |
+| `CLAUDE_4_7_OPUS` | `claude-opus-4-7` | No extended thinking | $5/$25/MTok. Requires `top_p=0.99`; no `thinking` or `temperature`. |
 
-**Naming note**: 4.6+ models dropped the date suffix — `claude-opus-4-6` is both the API ID and the alias.
+**Naming note**: 4.6+ Opus/Sonnet models dropped the date suffix — e.g. `claude-opus-4-7` is both the API ID and the alias.
 
 ### OpenAI
 
@@ -242,6 +243,13 @@ This section is a snapshot — update it whenever you run a model update pass.
 | `GPT_5_2_CODEX` | `gpt-5.2-codex` | Yes |
 | `GPT_5_2_PRO` | `gpt-5.2-pro` | Yes |
 | `GPT_5_3_CODEX` | `gpt-5.3-codex` | Yes |
+| `GPT_5_3_CHAT` | `gpt-5.3-chat-latest` | No |
+| `GPT_5_4` | `gpt-5.4` | Yes |
+| `GPT_5_4_PRO` | `gpt-5.4-pro` | Yes |
+| `GPT_5_4_MINI` | `gpt-5.4-mini` | Yes |
+| `GPT_5_4_NANO` | `gpt-5.4-nano` | Yes |
+| `GPT_5_5` | `gpt-5.5` | Yes |
+| `GPT_5_5_PRO` | `gpt-5.5-pro` | Yes |
 
 ### Google Gemini
 
@@ -251,8 +259,9 @@ This section is a snapshot — update it whenever you run a model update pass.
 | `GEMINI_2_5_FLASH` | `gemini-2.5-flash` | |
 | `GEMINI_2_5_PRO` | `gemini-2.5-pro` | |
 | `GEMINI_3_FLASH_PREVIEW` | `gemini-3-flash-preview` | |
-| `GEMINI_3_PRO_PREVIEW` | `gemini-3-pro-preview` | Retiring March 9, 2026 |
+| `GEMINI_3_PRO_PREVIEW` | `gemini-3-pro-preview` | Shut down March 9, 2026; now points to Gemini 3.1 Pro Preview |
 | `GEMINI_3_1_PRO` | `gemini-3.1-pro-preview` | 1M context |
+| `GEMINI_3_1_FLASH_LITE` | `gemini-3.1-flash-lite-preview` | 1M context |
 
 ---
 
@@ -291,8 +300,15 @@ After completing an update pass, always report:
 - [OpenAI GPT-5.1 for Developers](https://openai.com/index/gpt-5-1-for-developers/)
 - [OpenAI Introducing GPT-5.2](https://openai.com/index/introducing-gpt-5-2/)
 - [OpenAI Introducing GPT-5.3-Codex](https://openai.com/index/introducing-gpt-5-3-codex/)
+- [OpenAI GPT-5.4 Model](https://developers.openai.com/api/docs/models/gpt-5.4)
+- [OpenAI GPT-5.4 Mini Model](https://developers.openai.com/api/docs/models/gpt-5.4-mini)
+- [OpenAI GPT-5.4 Nano Model](https://developers.openai.com/api/docs/models/gpt-5.4-nano)
+- [OpenAI GPT-5.5 Model](https://developers.openai.com/api/docs/models/gpt-5.5)
+- [OpenAI GPT-5.5 Pro Model](https://developers.openai.com/api/docs/models/gpt-5.5-pro)
 - [Google Gemini API Models](https://ai.google.dev/gemini-api/docs/models)
+- [Google Gemini API Pricing](https://ai.google.dev/gemini-api/docs/pricing)
 - [Google Gemini 3.1 Pro Preview (Vertex AI)](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-pro)
 - [Google Gemini 2.5 Flash-Lite](https://ai.google.dev/gemini-api/docs/models/gemini-2.5-flash-lite)
+- [Azure OpenAI Models](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models)
 - [Azure AI Foundry What's New Dec 2025/Jan 2026](https://devblogs.microsoft.com/foundry/whats-new-in-microsoft-foundry-dec-2025-jan-2026/)
 - [Azure Claude Opus 4.6 Blog](https://azure.microsoft.com/en-us/blog/claude-opus-4-6-anthropics-powerful-model-for-coding-agents-and-enterprise-workflows-is-now-available-in-microsoft-foundry-on-azure/)

--- a/packages/agent-sdk/.cursor/rules/model-update.mdc
+++ b/packages/agent-sdk/.cursor/rules/model-update.mdc
@@ -174,7 +174,17 @@ Factories at `spaik_sdk/models/factories/`:
 - OpenAI factory: handles reasoning effort levels, `use_responses_api`. Update if new models need different behavior.
 - Google factory: handles thinking_budget. All Gemini models use same logic.
 
-### 5.5 (If new provider) Add new factory + provider
+### 5.5 Documentation — always keep model examples in sync
+
+When model defaults, recommended aliases, or visible registry examples change, update:
+
+- `README.md` — root package overview and model examples
+- `packages/agent-sdk/README.md` — Python SDK model examples
+- `AGENTS.md` — assistant guidance and model registry examples
+
+Do this as part of the same change as the model registry update, not as a later cleanup.
+
+### 5.6 (If new provider) Add new factory + provider
 
 If adding a model from a brand new provider:
 1. Create `spaik_sdk/models/llm_families.py` constant

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -219,12 +219,15 @@ ModelRegistry.CLAUDE_4_5_SONNET
 ModelRegistry.CLAUDE_4_5_OPUS
 ModelRegistry.CLAUDE_4_6_SONNET
 ModelRegistry.CLAUDE_4_6_OPUS
+ModelRegistry.CLAUDE_4_7_OPUS
 
 # OpenAI
 ModelRegistry.GPT_4_1
 ModelRegistry.GPT_4O
 ModelRegistry.O4_MINI
 ModelRegistry.GPT_5_4
+ModelRegistry.GPT_5_4_NANO
+ModelRegistry.GPT_5_5
 
 # Google
 ModelRegistry.GEMINI_2_5_FLASH
@@ -242,7 +245,7 @@ ModelRegistry.KIMI_K2_THINKING
 # Aliases
 ModelRegistry.from_name("sonnet")      # CLAUDE_4_6_SONNET
 ModelRegistry.from_name("gpt 4.1")     # GPT_4_1
-ModelRegistry.from_name("gemini 2.5")  # GEMINI_2_5_FLASH
+ModelRegistry.from_name("opus")        # CLAUDE_4_7_OPUS
 
 # Custom model
 from spaik_sdk.models.llm_model import LLMModel

--- a/packages/agent-sdk/spaik_sdk/llm/cost/builtin_cost_provider.py
+++ b/packages/agent-sdk/spaik_sdk/llm/cost/builtin_cost_provider.py
@@ -21,8 +21,8 @@ class BuiltinCostProvider(CostProvider):
         elif name.startswith("claude-sonnet-4") or name.startswith("claude-4-sonnet"):
             # Claude 4 Sonnet (all versions): $3.00 input, $15.00 output per 1M tokens
             return TokenUsage(input_tokens=300, output_tokens=1500, reasoning_tokens=0, cache_creation_tokens=375, cache_read_tokens=30)
-        elif name.startswith("claude-opus-4-5") or name.startswith("claude-opus-4-6"):
-            # Claude Opus 4.5 / 4.6: $5.00 input, $25.00 output per 1M tokens
+        elif name.startswith("claude-opus-4-5") or name.startswith("claude-opus-4-6") or name.startswith("claude-opus-4-7"):
+            # Claude Opus 4.5 / 4.6 / 4.7: $5.00 input, $25.00 output per 1M tokens
             return TokenUsage(input_tokens=500, output_tokens=2500, reasoning_tokens=0, cache_creation_tokens=625, cache_read_tokens=50)
         elif name.startswith("claude-opus-4") or name.startswith("claude-4-opus"):
             # Claude Opus 4 / 4.1: $15.00 input, $75.00 output per 1M tokens
@@ -49,6 +49,24 @@ class BuiltinCostProvider(CostProvider):
             )
 
         # OpenAI models — current
+        elif name.startswith("gpt-5.5-pro"):
+            # GPT-5.5 Pro: $30.00 input, $180.00 output per 1M tokens
+            return TokenUsage(input_tokens=3000, output_tokens=18000, reasoning_tokens=18000, cache_creation_tokens=0, cache_read_tokens=0)
+        elif name.startswith("gpt-5.5"):
+            # GPT-5.5: $5.00 input, $30.00 output per 1M tokens
+            return TokenUsage(input_tokens=500, output_tokens=3000, reasoning_tokens=3000, cache_creation_tokens=625, cache_read_tokens=50)
+        elif name.startswith("gpt-5.4-pro"):
+            # GPT-5.4 Pro: $30.00 input, $180.00 output per 1M tokens
+            return TokenUsage(input_tokens=3000, output_tokens=18000, reasoning_tokens=18000, cache_creation_tokens=0, cache_read_tokens=0)
+        elif name.startswith("gpt-5.4-nano"):
+            # GPT-5.4 Nano: $0.20 input, $1.25 output per 1M tokens
+            return TokenUsage(input_tokens=20, output_tokens=125, reasoning_tokens=125, cache_creation_tokens=25, cache_read_tokens=2)
+        elif name.startswith("gpt-5.4-mini"):
+            # GPT-5.4 Mini: $0.75 input, $4.50 output per 1M tokens
+            return TokenUsage(input_tokens=75, output_tokens=450, reasoning_tokens=450, cache_creation_tokens=94, cache_read_tokens=7)
+        elif name.startswith("gpt-5.4"):
+            # GPT-5.4: $2.50 input, $15.00 output per 1M tokens
+            return TokenUsage(input_tokens=250, output_tokens=1500, reasoning_tokens=1500, cache_creation_tokens=312, cache_read_tokens=25)
         elif name.startswith("gpt-5"):
             if "nano" in name:
                 # GPT-5 Nano: $0.05 input, $0.40 output per 1M tokens
@@ -89,8 +107,8 @@ class BuiltinCostProvider(CostProvider):
             # Gemini 2.5 Pro: $1.25 input, $10.00 output per 1M tokens
             return TokenUsage(input_tokens=125, output_tokens=1000, reasoning_tokens=0, cache_creation_tokens=156, cache_read_tokens=12)
         elif name.startswith("gemini-3.1-pro"):
-            # Gemini 3.1 Pro: $2.00 input, $18.00 output per 1M tokens
-            return TokenUsage(input_tokens=200, output_tokens=1800, reasoning_tokens=0, cache_creation_tokens=250, cache_read_tokens=20)
+            # Gemini 3.1 Pro: $2.00 input, $12.00 output per 1M tokens for prompts <= 200k tokens
+            return TokenUsage(input_tokens=200, output_tokens=1200, reasoning_tokens=0, cache_creation_tokens=250, cache_read_tokens=20)
         elif name.startswith("gemini-3.1-flash-lite"):
             # Gemini 3.1 Flash-Lite: $0.25 input, $1.50 output per 1M tokens
             return TokenUsage(input_tokens=25, output_tokens=150, reasoning_tokens=0, cache_creation_tokens=31, cache_read_tokens=2)
@@ -98,8 +116,8 @@ class BuiltinCostProvider(CostProvider):
             # Gemini 3 Pro: $1.25 input, $10.00 output per 1M tokens (deprecated on Google API March 9, 2026)
             return TokenUsage(input_tokens=125, output_tokens=1000, reasoning_tokens=0, cache_creation_tokens=156, cache_read_tokens=12)
         elif name.startswith("gemini-3-flash"):
-            # Gemini 3 Flash: $0.15 input, $0.60 output per 1M tokens
-            return TokenUsage(input_tokens=15, output_tokens=60, reasoning_tokens=0, cache_creation_tokens=19, cache_read_tokens=1)
+            # Gemini 3 Flash: $0.50 input, $3.00 output per 1M tokens
+            return TokenUsage(input_tokens=50, output_tokens=300, reasoning_tokens=0, cache_creation_tokens=62, cache_read_tokens=5)
 
         # Default fallback for unknown models
         else:

--- a/packages/agent-sdk/spaik_sdk/models/factories/anthropic_factory.py
+++ b/packages/agent-sdk/spaik_sdk/models/factories/anthropic_factory.py
@@ -17,7 +17,7 @@ class AnthropicModelFactory(BaseModelFactory):
         return {"type": "ephemeral"}
 
     def get_model_specific_config(self, config: LLMConfig) -> Dict[str, Any]:
-        allow_reasoning = config.reasoning and not config.structured_response
+        allow_reasoning = config.reasoning and config.model.reasoning and not config.structured_response
         model_config: Dict[str, Any] = {
             "model_name": config.model.name,
             "streaming": config.streaming,
@@ -27,6 +27,8 @@ class AnthropicModelFactory(BaseModelFactory):
         # Handle thinking mode via model_kwargs for LangChain compatibility
         if allow_reasoning:
             model_config["thinking"] = {"type": "enabled", "budget_tokens": config.reasoning_budget_tokens}
+        elif config.model == ModelRegistry.CLAUDE_4_7_OPUS:
+            model_config["top_p"] = 0.99
         else:
             model_config["temperature"] = config.temperature
 

--- a/packages/agent-sdk/spaik_sdk/models/model_registry.py
+++ b/packages/agent-sdk/spaik_sdk/models/model_registry.py
@@ -21,6 +21,7 @@ class ModelRegistry:
     CLAUDE_4_5_OPUS = LLMModel(family=LLMFamilies.ANTHROPIC, name="claude-opus-4-5-20251101", prompt_caching=True)
     CLAUDE_4_6_OPUS = LLMModel(family=LLMFamilies.ANTHROPIC, name="claude-opus-4-6", prompt_caching=True)
     CLAUDE_4_6_SONNET = LLMModel(family=LLMFamilies.ANTHROPIC, name="claude-sonnet-4-6", prompt_caching=True)
+    CLAUDE_4_7_OPUS = LLMModel(family=LLMFamilies.ANTHROPIC, name="claude-opus-4-7", reasoning=False, prompt_caching=True)
 
     # OpenAI models — legacy (deprecated on OpenAI direct API, still available on Azure and other providers)
     GPT_4_1 = LLMModel(family=LLMFamilies.OPENAI, name="gpt-4.1", reasoning=False, prompt_caching=True)
@@ -56,8 +57,11 @@ class ModelRegistry:
     GPT_5_3_CODEX = LLMModel(family=LLMFamilies.OPENAI, name="gpt-5.3-codex", reasoning=True, prompt_caching=True)
     GPT_5_3_CHAT = LLMModel(family=LLMFamilies.OPENAI, name="gpt-5.3-chat-latest", reasoning=False, prompt_caching=True)
     GPT_5_4 = LLMModel(family=LLMFamilies.OPENAI, name="gpt-5.4", reasoning=True, prompt_caching=True)
-    GPT_5_4_PRO = LLMModel(family=LLMFamilies.OPENAI, name="gpt-5.4-pro", reasoning=True, prompt_caching=True)
+    GPT_5_4_PRO = LLMModel(family=LLMFamilies.OPENAI, name="gpt-5.4-pro", reasoning=True)
     GPT_5_4_MINI = LLMModel(family=LLMFamilies.OPENAI, name="gpt-5.4-mini", reasoning=True, prompt_caching=True)
+    GPT_5_4_NANO = LLMModel(family=LLMFamilies.OPENAI, name="gpt-5.4-nano", reasoning=True, prompt_caching=True)
+    GPT_5_5 = LLMModel(family=LLMFamilies.OPENAI, name="gpt-5.5", reasoning=True, prompt_caching=True)
+    GPT_5_5_PRO = LLMModel(family=LLMFamilies.OPENAI, name="gpt-5.5-pro", reasoning=True)
 
     # Google models
     GEMINI_2_5_FLASH = LLMModel(family=LLMFamilies.GOOGLE, name="gemini-2.5-flash", prompt_caching=True)
@@ -146,16 +150,19 @@ class ModelRegistry:
             "sonnet 4.6": cls.CLAUDE_4_6_SONNET,
             "haiku": cls.CLAUDE_4_5_HAIKU,
             "haiku 4.5": cls.CLAUDE_4_5_HAIKU,
-            "opus": cls.CLAUDE_4_6_OPUS,
+            "opus": cls.CLAUDE_4_7_OPUS,
             "opus 4.1": cls.CLAUDE_4_1_OPUS,
             "opus 4.5": cls.CLAUDE_4_5_OPUS,
             "opus 4.6": cls.CLAUDE_4_6_OPUS,
+            "opus 4.7": cls.CLAUDE_4_7_OPUS,
             "claude 4.1 opus": cls.CLAUDE_4_1_OPUS,
             "claude opus 4.1": cls.CLAUDE_4_1_OPUS,
             "claude 4.5 opus": cls.CLAUDE_4_5_OPUS,
             "claude opus 4.5": cls.CLAUDE_4_5_OPUS,
             "claude 4.6 opus": cls.CLAUDE_4_6_OPUS,
             "claude opus 4.6": cls.CLAUDE_4_6_OPUS,
+            "claude 4.7 opus": cls.CLAUDE_4_7_OPUS,
+            "claude opus 4.7": cls.CLAUDE_4_7_OPUS,
             "claude 4.6 sonnet": cls.CLAUDE_4_6_SONNET,
             "claude sonnet 4.6": cls.CLAUDE_4_6_SONNET,
             "claude": cls.CLAUDE_4_6_SONNET,
@@ -198,6 +205,9 @@ class ModelRegistry:
             "gpt 5.4": cls.GPT_5_4,
             "gpt 5.4 pro": cls.GPT_5_4_PRO,
             "gpt 5.4 mini": cls.GPT_5_4_MINI,
+            "gpt 5.4 nano": cls.GPT_5_4_NANO,
+            "gpt 5.5": cls.GPT_5_5,
+            "gpt 5.5 pro": cls.GPT_5_5_PRO,
             # Gemini aliases
             "gemini 2.5 flash": cls.GEMINI_2_5_FLASH,
             "gemini 2.5 flash lite": cls.GEMINI_2_5_FLASH_LITE,

--- a/packages/agent-sdk/spaik_sdk/models/providers/azure_provider.py
+++ b/packages/agent-sdk/spaik_sdk/models/providers/azure_provider.py
@@ -13,6 +13,7 @@ from spaik_sdk.models.providers.base_provider import BaseProvider
 # Model name -> Environment variable for Azure deployment name
 AZURE_DEPLOYMENT_ENV_VARS: Dict[str, str] = {
     # Anthropic models (Azure AI Foundry)
+    "claude-opus-4-7": "AZURE_CLAUDE_OPUS_4_7_DEPLOYMENT",
     "claude-opus-4-6": "AZURE_CLAUDE_OPUS_4_6_DEPLOYMENT",
     "claude-sonnet-4-6": "AZURE_CLAUDE_SONNET_4_6_DEPLOYMENT",
     # OpenAI models
@@ -49,6 +50,8 @@ AZURE_DEPLOYMENT_ENV_VARS: Dict[str, str] = {
     "gpt-5.4": "AZURE_GPT_5_4_DEPLOYMENT",
     "gpt-5.4-pro": "AZURE_GPT_5_4_PRO_DEPLOYMENT",
     "gpt-5.4-mini": "AZURE_GPT_5_4_MINI_DEPLOYMENT",
+    "gpt-5.4-nano": "AZURE_GPT_5_4_NANO_DEPLOYMENT",
+    "gpt-5.5": "AZURE_GPT_5_5_DEPLOYMENT",
     # DeepSeek models (Azure AI Foundry)
     "DeepSeek-V3-0324": "AZURE_DEEPSEEK_V3_DEPLOYMENT",
     "DeepSeek-V3.1": "AZURE_DEEPSEEK_V3_1_DEPLOYMENT",

--- a/packages/agent-sdk/tests/unit/spaik_sdk/llm/cost/test_builtin_cost_provider.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/llm/cost/test_builtin_cost_provider.py
@@ -1,0 +1,25 @@
+import pytest
+
+from spaik_sdk.llm.cost.builtin_cost_provider import BuiltinCostProvider
+from spaik_sdk.models.model_registry import ModelRegistry
+
+
+@pytest.mark.unit
+class TestBuiltinCostProvider:
+    @pytest.mark.parametrize(
+        "model,expected_input,expected_output,expected_cache_read",
+        [
+            (ModelRegistry.CLAUDE_4_7_OPUS, 500, 2500, 50),
+            (ModelRegistry.GPT_5_4_NANO, 20, 125, 2),
+            (ModelRegistry.GPT_5_5, 500, 3000, 50),
+            (ModelRegistry.GPT_5_5_PRO, 3000, 18000, 0),
+            (ModelRegistry.GEMINI_3_FLASH, 50, 300, 5),
+            (ModelRegistry.GEMINI_3_1_PRO, 200, 1200, 20),
+        ],
+    )
+    def test_latest_model_pricing(self, model, expected_input: int, expected_output: int, expected_cache_read: int):
+        pricing = BuiltinCostProvider().get_token_pricing(model)
+
+        assert pricing.input_tokens == expected_input
+        assert pricing.output_tokens == expected_output
+        assert pricing.cache_read_tokens == expected_cache_read

--- a/packages/agent-sdk/tests/unit/spaik_sdk/models/factories/test_anthropic_factory.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/models/factories/test_anthropic_factory.py
@@ -1,0 +1,25 @@
+import pytest
+
+from spaik_sdk.models.factories.anthropic_factory import AnthropicModelFactory
+from spaik_sdk.models.llm_config import LLMConfig
+from spaik_sdk.models.model_registry import ModelRegistry
+
+
+@pytest.mark.unit
+class TestAnthropicModelFactory:
+    def test_reasoning_model_sets_thinking_config(self):
+        config = LLMConfig(model=ModelRegistry.CLAUDE_4_6_SONNET, reasoning=True, reasoning_budget_tokens=2048)
+
+        model_config = AnthropicModelFactory().get_model_specific_config(config)
+
+        assert model_config["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+        assert "temperature" not in model_config
+
+    def test_claude_opus_4_7_uses_required_top_p_without_thinking_or_temperature(self):
+        config = LLMConfig(model=ModelRegistry.CLAUDE_4_7_OPUS, reasoning=True, temperature=0.7)
+
+        model_config = AnthropicModelFactory().get_model_specific_config(config)
+
+        assert model_config["top_p"] == 0.99
+        assert "thinking" not in model_config
+        assert "temperature" not in model_config

--- a/packages/agent-sdk/tests/unit/spaik_sdk/models/factories/test_openai_factory.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/models/factories/test_openai_factory.py
@@ -167,6 +167,12 @@ class TestOpenAIModelFactoryReasoning:
             ModelRegistry.GPT_5_1_CODEX_MAX,
             ModelRegistry.GPT_5_2,
             ModelRegistry.GPT_5_2_PRO,
+            ModelRegistry.GPT_5_4,
+            ModelRegistry.GPT_5_4_PRO,
+            ModelRegistry.GPT_5_4_MINI,
+            ModelRegistry.GPT_5_4_NANO,
+            ModelRegistry.GPT_5_5,
+            ModelRegistry.GPT_5_5_PRO,
         ],
     )
     def test_reasoning_true_enables_responses_api_for_all_reasoning_models(self, factory, model):
@@ -220,6 +226,9 @@ class TestOpenAIModelFactoryParameterized:
             (ModelRegistry.GPT_5_4, "none"),
             (ModelRegistry.GPT_5_4_PRO, "none"),
             (ModelRegistry.GPT_5_4_MINI, "none"),
+            (ModelRegistry.GPT_5_4_NANO, "none"),
+            (ModelRegistry.GPT_5_5, "none"),
+            (ModelRegistry.GPT_5_5_PRO, "none"),
             # GPT-5 base models -> effort='minimal'
             (ModelRegistry.GPT_5, "minimal"),
             (ModelRegistry.GPT_5_MINI, "minimal"),

--- a/packages/agent-sdk/tests/unit/spaik_sdk/models/test_model_registry.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/models/test_model_registry.py
@@ -12,6 +12,9 @@ class TestModelRegistry:
             ("opus 4.5", "claude-opus-4-5-20251101"),
             ("claude opus 4.5", "claude-opus-4-5-20251101"),
             ("claude 4.5 opus", "claude-opus-4-5-20251101"),
+            ("opus", "claude-opus-4-7"),
+            ("opus 4.7", "claude-opus-4-7"),
+            ("claude opus 4.7", "claude-opus-4-7"),
             ("gpt 5.1", "gpt-5.1"),
             ("gpt 5.1 codex", "gpt-5.1-codex"),
             ("gpt 5.1 codex mini", "gpt-5.1-codex-mini"),
@@ -22,6 +25,9 @@ class TestModelRegistry:
             ("gpt 5.4", "gpt-5.4"),
             ("gpt 5.4 pro", "gpt-5.4-pro"),
             ("gpt 5.4 mini", "gpt-5.4-mini"),
+            ("gpt 5.4 nano", "gpt-5.4-nano"),
+            ("gpt 5.5", "gpt-5.5"),
+            ("gpt 5.5 pro", "gpt-5.5-pro"),
             ("gemini 3 flash", "gemini-3-flash-preview"),
             ("gemini 3.0 flash", "gemini-3-flash-preview"),
             ("gemini 3 pro", "gemini-3-pro-preview"),
@@ -38,6 +44,7 @@ class TestModelRegistry:
         "model_name",
         [
             "claude-opus-4-5-20251101",
+            "claude-opus-4-7",
             "gpt-5.1",
             "gpt-5.1-codex",
             "gpt-5.1-codex-mini",
@@ -48,6 +55,9 @@ class TestModelRegistry:
             "gpt-5.4",
             "gpt-5.4-pro",
             "gpt-5.4-mini",
+            "gpt-5.4-nano",
+            "gpt-5.5",
+            "gpt-5.5-pro",
             "gemini-3-flash-preview",
             "gemini-3-pro-preview",
             "gemini-3.1-pro-preview",
@@ -67,6 +77,11 @@ class TestModelRegistry:
         assert ModelRegistry.GPT_5_4.reasoning is True
         assert ModelRegistry.GPT_5_4_PRO.reasoning is True
         assert ModelRegistry.GPT_5_4_MINI.reasoning is True
+        assert ModelRegistry.GPT_5_4_NANO.reasoning is True
+
+    def test_gpt_5_5_variants_have_reasoning_enabled(self):
+        assert ModelRegistry.GPT_5_5.reasoning is True
+        assert ModelRegistry.GPT_5_5_PRO.reasoning is True
 
     def test_gemini_3_models_use_google_family(self):
         assert ModelRegistry.GEMINI_3_FLASH.family == LLMFamilies.GOOGLE
@@ -74,8 +89,10 @@ class TestModelRegistry:
         assert ModelRegistry.GEMINI_3_1_PRO.family == LLMFamilies.GOOGLE
         assert ModelRegistry.GEMINI_3_1_FLASH_LITE.family == LLMFamilies.GOOGLE
 
-    def test_claude_4_5_opus_uses_anthropic_family(self):
+    def test_claude_opus_models_use_anthropic_family(self):
         assert ModelRegistry.CLAUDE_4_5_OPUS.family == LLMFamilies.ANTHROPIC
+        assert ModelRegistry.CLAUDE_4_7_OPUS.family == LLMFamilies.ANTHROPIC
+        assert ModelRegistry.CLAUDE_4_7_OPUS.reasoning is False
 
     def test_ambiguous_model_name_raises_error(self):
         with pytest.raises(ValueError, match="Ambiguous"):
@@ -89,10 +106,14 @@ class TestModelRegistry:
         all_models = ModelRegistry.get_all()
         model_names = {m.name for m in all_models}
         assert "claude-opus-4-5-20251101" in model_names
+        assert "claude-opus-4-7" in model_names
         assert "gpt-5.1" in model_names
         assert "gpt-5.2" in model_names
         assert "gpt-5.4" in model_names
         assert "gpt-5.4-pro" in model_names
+        assert "gpt-5.4-nano" in model_names
+        assert "gpt-5.5" in model_names
+        assert "gpt-5.5-pro" in model_names
         assert "gemini-3-flash-preview" in model_names
         assert "gemini-3-pro-preview" in model_names
         assert "gemini-3.1-pro-preview" in model_names


### PR DESCRIPTION
## Summary
- Add verified Claude Opus 4.7, GPT-5.4 Nano, GPT-5.5, and GPT-5.5 Pro model registry entries and aliases.
- Update pricing, Azure deployment mappings, and Claude Opus 4.7 provider config.
- Refresh model documentation and add focused unit coverage for registry lookup, pricing, and provider config.

## Test plan
- `uv run python3 -m pytest tests/unit/spaik_sdk/models/test_model_registry.py tests/unit/spaik_sdk/models/factories/test_openai_factory.py tests/unit/spaik_sdk/models/factories/test_anthropic_factory.py tests/unit/spaik_sdk/llm/cost/test_builtin_cost_provider.py --no-cov`
- `make lint-fix && make typecheck && make test-unit`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Opus 4.7, GPT 5.4 Nano, GPT 5.5, and GPT 5.5 Pro models
  * Updated "opus" alias to resolve to the latest Claude Opus model
  * Updated token pricing for new and existing models

* **Documentation**
  * Updated model registry documentation and examples

* **Tests**
  * Added comprehensive test coverage for new models and pricing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->