### PR TITLE
fix(tracing): include tool responses in traces

### DIFF
--- a/packages/agent-sdk/spaik_sdk/tracing/agent_trace.py
+++ b/packages/agent-sdk/spaik_sdk/tracing/agent_trace.py
@@ -10,6 +10,12 @@ from spaik_sdk.tracing.get_trace_sink import get_trace_sink
 from spaik_sdk.tracing.trace_sink import TraceSink
 
 
+def _format_trace_payload(payload: object) -> str:
+    if isinstance(payload, str):
+        return payload
+    return json.dumps(payload, indent=2, default=str)
+
+
 class AgentTrace:
     def __init__(
         self,
@@ -52,9 +58,9 @@ class AgentTrace:
         elif block.type == MessageBlockType.TOOL_USE:
             tool_step = f"🔧: {block.tool_name} {json.dumps(block.tool_call_args, indent=2)}"
             if block.tool_call_response is not None:
-                tool_step += f"\n\n🔧 response: {block.tool_call_response}"
+                tool_step += f"\n\n🔧 response: {_format_trace_payload(block.tool_call_response)}"
             if block.tool_call_error is not None:
-                tool_step += f"\n\n🚨 tool error: {block.tool_call_error}"
+                tool_step += f"\n\n🚨 tool error: {_format_trace_payload(block.tool_call_error)}"
             self.add_step(tool_step)
         elif block.type == MessageBlockType.ERROR:
             self.add_step(f"🚨: {block.content}")

--- a/packages/agent-sdk/spaik_sdk/tracing/agent_trace.py
+++ b/packages/agent-sdk/spaik_sdk/tracing/agent_trace.py
@@ -50,7 +50,12 @@ class AgentTrace:
         elif block.type == MessageBlockType.REASONING:
             self.add_step(f"🧠: {block.content}")
         elif block.type == MessageBlockType.TOOL_USE:
-            self.add_step(f"🔧: {block.tool_name} {json.dumps(block.tool_call_args, indent=2)}")
+            tool_step = f"🔧: {block.tool_name} {json.dumps(block.tool_call_args, indent=2)}"
+            if block.tool_call_response is not None:
+                tool_step += f"\n\n🔧 response: {block.tool_call_response}"
+            if block.tool_call_error is not None:
+                tool_step += f"\n\n🚨 tool error: {block.tool_call_error}"
+            self.add_step(tool_step)
         elif block.type == MessageBlockType.ERROR:
             self.add_step(f"🚨: {block.content}")
         else:

--- a/packages/agent-sdk/tests/unit/spaik_sdk/tracing/test_tracing.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/tracing/test_tracing.py
@@ -390,6 +390,7 @@ class TestAgentTrace:
         rendered = trace.to_string(include_system_prompt=False)
         assert "🔧: calculator" in rendered
         assert '"expression": "2 + 2"' in rendered
+        assert "🔧 response: 4" in rendered
 
 
 @pytest.mark.unit

--- a/packages/agent-sdk/tests/unit/spaik_sdk/tracing/test_tracing.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/tracing/test_tracing.py
@@ -386,11 +386,26 @@ class TestAgentTrace:
         )
         thread.add_tool_call_response(ToolCallResponse(id="call-1", response="4"))
         thread.finalize_streaming_blocks(message_id, ["tool-1"])
+        thread.add_message_block(
+            message_id,
+            MessageBlock(
+                id="tool-err",
+                streaming=True,
+                type=MessageBlockType.TOOL_USE,
+                tool_name="fragile_tool",
+                tool_call_id="call-err",
+                tool_call_args={"input": "bad"},
+            ),
+        )
+        thread.add_tool_call_response(ToolCallResponse(id="call-err", response="", error="tool failed"))
+        thread.finalize_streaming_blocks(message_id, ["tool-err"])
 
         rendered = trace.to_string(include_system_prompt=False)
         assert "🔧: calculator" in rendered
         assert '"expression": "2 + 2"' in rendered
         assert "🔧 response: 4" in rendered
+        assert "🔧: fragile_tool" in rendered
+        assert "🚨 tool error: tool failed" in rendered
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Render tool call responses and tool errors in `AgentTrace` output.
- Extend the tracing unit test to cover completed tool-call answers.

## Test plan
- `uv run python3 -m pytest tests/unit/spaik_sdk/tracing/test_tracing.py -q`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent trace output now captures and displays tool responses and errors alongside tool names and arguments, providing enhanced visibility into tool execution details and diagnostics.

* **Tests**
  * Enhanced test coverage to verify tool-call responses are correctly rendered in agent trace output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->