### PR TITLE
fix(agent-sdk): stream OpenAI reasoning summaries

### DIFF
--- a/packages/agent-sdk/spaik_sdk/llm/streaming/streaming_event_handler.py
+++ b/packages/agent-sdk/spaik_sdk/llm/streaming/streaming_event_handler.py
@@ -167,8 +167,8 @@ class StreamingEventHandler:
                         async for event in self.content_handler.handle_regular_content(block.get("text", "")):
                             yield event
                         self.state_manager.mark_text_content_received()
-                    elif block_type in ("reasoning", "thinking"):
-                        reasoning = block.get("reasoning", "") or block.get("thinking", "")
+                    elif block_type in ("reasoning", "thinking", "reasoning_summary"):
+                        reasoning = block.get("reasoning", "") or block.get("thinking", "") or block.get("text", "")
                         async for event in self.content_handler.handle_reasoning_content(reasoning):
                             yield event
                 elif isinstance(block, str) and block:

--- a/packages/agent-sdk/tests/unit/spaik_sdk/llm/streaming/test_streaming_event_handler.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/llm/streaming/test_streaming_event_handler.py
@@ -169,6 +169,25 @@ class TestStreamingEventHandler:
         assert token_events[0].content == "Answer"
 
     @pytest.mark.asyncio
+    async def test_handles_openai_reasoning_summary_blocks(self):
+        handler = StreamingEventHandler()
+        chunk = AIMessageChunk(content=[{"type": "reasoning_summary", "text": "I checked the constraints."}])
+        raw_events = [
+            {"event": "on_chat_model_stream", "data": {"chunk": chunk}},
+            make_chat_model_stream_event("Answer"),
+            make_chain_end_event(),
+        ]
+
+        events = await collect_events(handler, raw_events)
+
+        reasoning_events = [e for e in events if e.event_type == EventType.REASONING]
+        token_events = [e for e in events if e.event_type == EventType.TOKEN]
+        assert len(reasoning_events) == 1
+        assert reasoning_events[0].content == "I checked the constraints."
+        assert len(token_events) == 1
+        assert token_events[0].content == "Answer"
+
+    @pytest.mark.asyncio
     async def test_handles_tool_calls(self):
         handler = StreamingEventHandler()
         raw_events = [


### PR DESCRIPTION
## Summary
- Handle OpenAI Responses API `reasoning_summary` content blocks in the streaming event handler.
- Route summary text through the existing reasoning block path so it reaches thread events, frontend consumers, and traces.
- Add a regression test for the OpenAI `reasoning_summary` block shape.

## Test plan
- `make lint-fix && make typecheck && make test-unit`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reasoning summary content blocks in streaming responses from the AI model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->