### PR TITLE
fix(agent-sdk): allow model-less llm config in base agent

### DIFF
--- a/packages/agent-sdk/spaik_sdk/agent/base_agent.py
+++ b/packages/agent-sdk/spaik_sdk/agent/base_agent.py
@@ -3,6 +3,7 @@ import contextvars
 import threading
 import uuid
 from abc import ABC
+from dataclasses import replace
 from typing import Any, AsyncGenerator, Dict, List, Optional, Type, TypeVar
 
 from langchain_core.language_models import BaseChatModel
@@ -80,7 +81,9 @@ class BaseAgent(ABC):
         self.thread_container = thread_container if thread_container is not None else ThreadContainer(self.system_prompt)
         self.tools = tools if tools is not None else self._create_tools(self.tool_providers)
         self.thread_container.bind_tool_providers(self.tool_providers)
-        self.llm_config = llm_config if llm_config is not None else self.create_llm_config(llm_model, reasoning)
+        self.llm_config = (
+            self._normalize_llm_config(llm_config, llm_model) if llm_config is not None else self.create_llm_config(llm_model, reasoning)
+        )
         self.recorder = recorder.get_recorder() if recorder is not None else None
         self.playback = recorder.get_playback() if recorder is not None else None
         self.thread_container.subscribe(self._on_thread_event)
@@ -198,6 +201,24 @@ class BaseAgent(ABC):
             provider_type=self._resolve_provider_type(llm_model),
             reasoning=reasoning if reasoning is not None else llm_model.reasoning,
             tool_usage=len(self.tools) > 0,
+        )
+
+    def _normalize_llm_config(self, llm_config: LLMConfig, llm_model: Optional[LLMModel] = None) -> LLMConfig:
+        resolved_model = llm_config.model if llm_config.model is not None else llm_model
+        if resolved_model is None:
+            resolved_model = self.get_llm_model()
+
+        provider_type = llm_config.provider_type
+        if provider_type is None:
+            provider_type = self._resolve_provider_type(resolved_model)
+
+        if llm_config.model is resolved_model and llm_config.provider_type is provider_type:
+            return llm_config
+
+        return replace(
+            llm_config,
+            model=resolved_model,
+            provider_type=provider_type,
         )
 
     def _resolve_provider_type(self, llm_model: LLMModel) -> ProviderType:

--- a/packages/agent-sdk/spaik_sdk/models/llm_config.py
+++ b/packages/agent-sdk/spaik_sdk/models/llm_config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, replace
-from typing import Optional
+from typing import Optional, cast
 
 from spaik_sdk.models.llm_model import LLMModel
 from spaik_sdk.models.llm_wrapper import LLMWrapper
@@ -9,7 +9,7 @@ from spaik_sdk.models.providers.provider_type import ProviderType
 
 @dataclass
 class LLMConfig:
-    model: LLMModel
+    model: LLMModel = cast(LLMModel, None)
     provider_type: Optional[ProviderType] = None
     provider: Optional[BaseProvider] = None
     reasoning: bool = True

--- a/packages/agent-sdk/tests/unit/spaik_sdk/agent/test_base_agent.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/agent/test_base_agent.py
@@ -14,7 +14,9 @@ from spaik_sdk.agent.base_agent import BaseAgent
 from spaik_sdk.llm.cancellation_handle import CancellationHandle
 from spaik_sdk.llm.consumption.token_usage import TokenUsage
 from spaik_sdk.llm.cost.builtin_cost_provider import BuiltinCostProvider
+from spaik_sdk.models.llm_config import LLMConfig
 from spaik_sdk.models.model_registry import ModelRegistry
+from spaik_sdk.models.providers.provider_type import ProviderType
 from spaik_sdk.recording.conditional_recorder import ConditionalRecorder
 from spaik_sdk.recording.impl.local_recorder import LocalRecorder
 from spaik_sdk.thread.models import MessageBlockType
@@ -89,6 +91,14 @@ class DefaultToolProviderAgent(BaseAgent):
 
     def get_tool_providers(self) -> List[ToolProvider]:
         return [TestToolProvider()]
+
+
+class ConfigOnlyAgent(BaseAgent):
+    def __init__(self, **kwargs):
+        super().__init__(
+            system_prompt="test system prompt",
+            **kwargs,
+        )
 
 
 def assert_consumption_equals(actual_consumption: TokenUsage, expected_consumption: TokenUsage):
@@ -304,6 +314,52 @@ class TestBaseAgent:
         assert len(agent.tool_providers) == 1
         assert agent.tools == []
         assert agent.llm_config.tool_usage is False
+
+    def test_llm_config_without_model_uses_explicit_llm_model(self):
+        agent = ConfigOnlyAgent(
+            llm_config=LLMConfig(tool_usage=False, streaming=False),
+            llm_model=ModelRegistry.GPT_4_1,
+        )
+
+        assert agent.llm_config.model == ModelRegistry.GPT_4_1
+        assert agent.llm_config.provider_type == ProviderType.OPENAI_DIRECT
+
+    def test_llm_config_without_model_uses_default_model(self, monkeypatch):
+        monkeypatch.setenv("DEFAULT_MODEL", "claude-sonnet-4-20250514")
+        monkeypatch.delenv("MODEL_PROVIDER", raising=False)
+
+        agent = ConfigOnlyAgent(
+            llm_config=LLMConfig(tool_usage=False, streaming=False),
+        )
+
+        assert agent.llm_config.model == ModelRegistry.CLAUDE_4_SONNET
+        assert agent.llm_config.provider_type == ProviderType.ANTHROPIC
+
+    def test_llm_config_model_takes_precedence_over_llm_model_argument(self):
+        agent = ConfigOnlyAgent(
+            llm_config=LLMConfig(
+                model=ModelRegistry.GEMINI_2_5_FLASH,
+                tool_usage=False,
+                streaming=False,
+            ),
+            llm_model=ModelRegistry.CLAUDE_4_SONNET,
+        )
+
+        assert agent.llm_config.model == ModelRegistry.GEMINI_2_5_FLASH
+        assert agent.llm_config.provider_type == ProviderType.GOOGLE
+
+    def test_llm_config_preserves_explicit_provider_type(self):
+        agent = ConfigOnlyAgent(
+            llm_config=LLMConfig(
+                tool_usage=False,
+                streaming=False,
+                provider_type=ProviderType.AZURE_AI_FOUNDRY,
+            ),
+            llm_model=ModelRegistry.GPT_4_1,
+        )
+
+        assert agent.llm_config.model == ModelRegistry.GPT_4_1
+        assert agent.llm_config.provider_type == ProviderType.AZURE_AI_FOUNDRY
 
 
 @pytest.mark.unit

--- a/packages/agent-sdk/tests/unit/spaik_sdk/agent/test_base_agent.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/agent/test_base_agent.py
@@ -50,7 +50,7 @@ class ConcreteTestAgent(BaseAgent):
         )
 
 
-class TestToolProvider(ToolProvider):
+class SecretGreetingToolProvider(ToolProvider):
     def get_tools(self) -> List[BaseTool]:
         @tool
         def get_secret_greeting() -> str:
@@ -78,7 +78,7 @@ class ToolCallTestAgent(BaseAgent):
         )
 
     def get_tool_providers(self) -> List[ToolProvider]:
-        return [TestToolProvider()]
+        return [SecretGreetingToolProvider()]
 
 
 class DefaultToolProviderAgent(BaseAgent):
@@ -90,7 +90,7 @@ class DefaultToolProviderAgent(BaseAgent):
         )
 
     def get_tool_providers(self) -> List[ToolProvider]:
-        return [TestToolProvider()]
+        return [SecretGreetingToolProvider()]
 
 
 class ConfigOnlyAgent(BaseAgent):


### PR DESCRIPTION
## Summary
- allow `LLMConfig` to be constructed without a model for the `BaseAgent` constructor path
- normalize agent-provided `llm_config` values so missing models resolve from `llm_model` or `DEFAULT_MODEL`, and derive `provider_type` when needed
- add focused constructor regression tests and clean up the helper naming in the touched test file to avoid pytest collection warnings

## Test plan
- [x] `uv run pytest tests/unit/spaik_sdk/agent/test_base_agent.py`
- [x] `make lint-fix`
- [x] `make typecheck`
- [x] `make test-unit`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced LLM configuration handling with improved normalization and intelligent fallback selection for models and providers.
  * LLMConfig model field is now optional with sensible defaults, providing greater flexibility when initializing agent configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->