### PR TITLE
fix(agent-sdk): capture OpenAI reasoning summaries

### DIFF
--- a/packages/agent-sdk/spaik_sdk/llm/streaming/streaming_event_handler.py
+++ b/packages/agent-sdk/spaik_sdk/llm/streaming/streaming_event_handler.py
@@ -168,7 +168,7 @@ class StreamingEventHandler:
                             yield event
                         self.state_manager.mark_text_content_received()
                     elif block_type in ("reasoning", "thinking", "reasoning_summary"):
-                        reasoning = block.get("reasoning", "") or block.get("thinking", "") or block.get("text", "")
+                        reasoning = self._extract_reasoning_content(block)
                         async for event in self.content_handler.handle_reasoning_content(reasoning):
                             yield event
                 elif isinstance(block, str) and block:
@@ -187,6 +187,17 @@ class StreamingEventHandler:
                 self._tool_args_by_id[tool_id] = tool_args
                 async for event in self.content_handler.handle_tool_use(tool_id, tool_name, tool_args):
                     yield event
+
+    def _extract_reasoning_content(self, block: dict[str, Any]) -> str:
+        reasoning = block.get("reasoning") or block.get("thinking") or block.get("text")
+        if isinstance(reasoning, str):
+            return reasoning
+
+        summary = block.get("summary")
+        if not isinstance(summary, list):
+            return ""
+
+        return "".join(item.get("text", "") for item in summary if isinstance(item, dict))
 
     def _collect_final_tool_calls(self, message: AIMessageType) -> dict[str, tuple[str, str, dict]]:
         final_tool_calls = {

--- a/packages/agent-sdk/spaik_sdk/models/factories/openai_factory.py
+++ b/packages/agent-sdk/spaik_sdk/models/factories/openai_factory.py
@@ -17,11 +17,9 @@ class OpenAIModelFactory(BaseModelFactory):
         return model in OpenAIModelFactory.MODELS
 
     def supports_model_config(self, config: LLMConfig) -> bool:
-        # First check basic model support
         if not self.supports_model(config.model):
             return False
         if config.reasoning and not config.model.reasoning:
-            # let's not fail here, but we should log a warning
             logger.warning(f"Model {config.model} does not support reasoning")
         return True
 
@@ -37,21 +35,15 @@ class OpenAIModelFactory(BaseModelFactory):
         if config.tool_usage:
             model_kwargs["parallel_tool_calls"] = True
 
-        # Handle reasoning configuration based on user preference (config.reasoning)
-        # and model capability (config.model.reasoning)
         if config.model.reasoning:
-            # Model supports reasoning - check user preference
             model_config["use_responses_api"] = True
 
             if config.reasoning:
-                # User wants reasoning enabled - use configured effort
                 if config.reasoning_summary:
                     model_config["reasoning"] = {"effort": config.reasoning_effort, "summary": config.reasoning_summary}
             else:
-                # User wants reasoning disabled - use model's minimum effort level
                 model_config["reasoning"] = {"effort": config.model.reasoning_min_effort}
         else:
-            # Model doesn't support reasoning
             model_config["temperature"] = config.temperature
 
         if model_kwargs:

--- a/packages/agent-sdk/spaik_sdk/models/factories/openai_factory.py
+++ b/packages/agent-sdk/spaik_sdk/models/factories/openai_factory.py
@@ -46,10 +46,10 @@ class OpenAIModelFactory(BaseModelFactory):
             if config.reasoning:
                 # User wants reasoning enabled - use configured effort
                 if config.reasoning_summary:
-                    model_kwargs["reasoning"] = {"effort": config.reasoning_effort, "summary": config.reasoning_summary}
+                    model_config["reasoning"] = {"effort": config.reasoning_effort, "summary": config.reasoning_summary}
             else:
                 # User wants reasoning disabled - use model's minimum effort level
-                model_kwargs["reasoning"] = {"effort": config.model.reasoning_min_effort}
+                model_config["reasoning"] = {"effort": config.model.reasoning_min_effort}
         else:
             # Model doesn't support reasoning
             model_config["temperature"] = config.temperature

--- a/packages/agent-sdk/tests/unit/spaik_sdk/llm/streaming/test_streaming_event_handler.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/llm/streaming/test_streaming_event_handler.py
@@ -188,6 +188,36 @@ class TestStreamingEventHandler:
         assert token_events[0].content == "Answer"
 
     @pytest.mark.asyncio
+    async def test_handles_openai_reasoning_summary_list_blocks(self):
+        handler = StreamingEventHandler()
+        chunk = AIMessageChunk(
+            content=[
+                {
+                    "type": "reasoning",
+                    "id": "rs_123",
+                    "summary": [
+                        {"type": "summary_text", "text": "I checked the constraints. "},
+                        {"type": "summary_text", "text": "Then I answered."},
+                    ],
+                }
+            ]
+        )
+        raw_events = [
+            {"event": "on_chat_model_stream", "data": {"chunk": chunk}},
+            make_chat_model_stream_event("Answer"),
+            make_chain_end_event(),
+        ]
+
+        events = await collect_events(handler, raw_events)
+
+        reasoning_events = [e for e in events if e.event_type == EventType.REASONING]
+        token_events = [e for e in events if e.event_type == EventType.TOKEN]
+        assert len(reasoning_events) == 1
+        assert reasoning_events[0].content == "I checked the constraints. Then I answered."
+        assert len(token_events) == 1
+        assert token_events[0].content == "Answer"
+
+    @pytest.mark.asyncio
     async def test_handles_tool_calls(self):
         handler = StreamingEventHandler()
         raw_events = [

--- a/packages/agent-sdk/tests/unit/spaik_sdk/models/factories/test_openai_factory.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/models/factories/test_openai_factory.py
@@ -33,7 +33,7 @@ class TestOpenAIModelFactoryReasoning:
         # Should still use Responses API (model supports it)
         assert model_config["use_responses_api"] is True
         # But reasoning should be disabled per user preference
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == "none"
+        assert model_config["reasoning"]["effort"] == "none"
 
     # Tests for GPT-5.1+ models (support effort='none' for full disable)
 
@@ -46,7 +46,7 @@ class TestOpenAIModelFactoryReasoning:
 
         model_config = factory.get_model_specific_config(config)
 
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == "none"
+        assert model_config["reasoning"]["effort"] == "none"
 
     def test_reasoning_false_gpt_5_1_codex_sets_effort_none(self, factory):
         """When reasoning=False on GPT-5.1-codex model, reasoning effort is 'none'."""
@@ -57,7 +57,7 @@ class TestOpenAIModelFactoryReasoning:
 
         model_config = factory.get_model_specific_config(config)
 
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == "none"
+        assert model_config["reasoning"]["effort"] == "none"
 
     def test_reasoning_false_gpt_5_1_codex_mini_sets_effort_none(self, factory):
         """When reasoning=False on GPT-5.1-codex-mini model, reasoning effort is 'none'."""
@@ -68,7 +68,7 @@ class TestOpenAIModelFactoryReasoning:
 
         model_config = factory.get_model_specific_config(config)
 
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == "none"
+        assert model_config["reasoning"]["effort"] == "none"
 
     def test_reasoning_false_gpt_5_1_codex_max_sets_effort_none(self, factory):
         """When reasoning=False on GPT-5.1-codex-max model, reasoning effort is 'none'."""
@@ -79,7 +79,7 @@ class TestOpenAIModelFactoryReasoning:
 
         model_config = factory.get_model_specific_config(config)
 
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == "none"
+        assert model_config["reasoning"]["effort"] == "none"
 
     def test_reasoning_false_gpt_5_2_sets_effort_none(self, factory):
         """When reasoning=False on GPT-5.2 model, reasoning effort is 'none'."""
@@ -90,7 +90,7 @@ class TestOpenAIModelFactoryReasoning:
 
         model_config = factory.get_model_specific_config(config)
 
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == "none"
+        assert model_config["reasoning"]["effort"] == "none"
 
     def test_reasoning_false_gpt_5_2_pro_sets_effort_none(self, factory):
         """When reasoning=False on GPT-5.2-pro model, reasoning effort is 'none'."""
@@ -101,7 +101,7 @@ class TestOpenAIModelFactoryReasoning:
 
         model_config = factory.get_model_specific_config(config)
 
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == "none"
+        assert model_config["reasoning"]["effort"] == "none"
 
     # Tests for GPT-5 base models (only support effort='minimal')
 
@@ -114,7 +114,7 @@ class TestOpenAIModelFactoryReasoning:
 
         model_config = factory.get_model_specific_config(config)
 
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == "minimal"
+        assert model_config["reasoning"]["effort"] == "minimal"
 
     def test_reasoning_false_gpt_5_mini_sets_effort_minimal(self, factory):
         """When reasoning=False on GPT-5-mini model, reasoning effort is 'minimal'."""
@@ -125,7 +125,7 @@ class TestOpenAIModelFactoryReasoning:
 
         model_config = factory.get_model_specific_config(config)
 
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == "minimal"
+        assert model_config["reasoning"]["effort"] == "minimal"
 
     def test_reasoning_false_gpt_5_nano_sets_effort_minimal(self, factory):
         """When reasoning=False on GPT-5-nano model, reasoning effort is 'minimal'."""
@@ -136,7 +136,7 @@ class TestOpenAIModelFactoryReasoning:
 
         model_config = factory.get_model_specific_config(config)
 
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == "minimal"
+        assert model_config["reasoning"]["effort"] == "minimal"
 
     # Tests for reasoning=True (existing behavior preserved)
 
@@ -152,8 +152,8 @@ class TestOpenAIModelFactoryReasoning:
         model_config = factory.get_model_specific_config(config)
 
         assert model_config["use_responses_api"] is True
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == "high"
-        assert model_config["model_kwargs"]["reasoning"]["summary"] == "detailed"
+        assert model_config["reasoning"]["effort"] == "high"
+        assert model_config["reasoning"]["summary"] == "detailed"
 
     @pytest.mark.parametrize(
         "model",
@@ -202,7 +202,7 @@ class TestOpenAIModelFactoryReasoning:
 
         assert model_config["temperature"] == 0.7
         assert "use_responses_api" not in model_config
-        assert "reasoning" not in model_config.get("model_kwargs", {})
+        assert "reasoning" not in model_config
 
 
 @pytest.mark.unit
@@ -244,7 +244,7 @@ class TestOpenAIModelFactoryParameterized:
 
         model_config = factory.get_model_specific_config(config)
 
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == expected_effort
+        assert model_config["reasoning"]["effort"] == expected_effort
 
 
 @pytest.mark.unit
@@ -302,4 +302,4 @@ class TestOpenAIModelFactoryParallelToolCalls:
         model_config = factory.get_model_specific_config(config)
 
         assert model_config["model_kwargs"]["parallel_tool_calls"] is True
-        assert model_config["model_kwargs"]["reasoning"]["effort"] == "high"
+        assert model_config["reasoning"]["effort"] == "high"


### PR DESCRIPTION
## Summary
- Pass OpenAI reasoning config through LangChain's explicit `reasoning` parameter so Responses API summary settings are honored.
- Extract nested OpenAI reasoning `summary[]` text blocks into SDK reasoning events.
- Add regression coverage for the nested Responses API reasoning block shape.

## Test plan
- `make test-unit-single PATTERN='openai_factory or streaming_event_handler'`
- `make lint-fix && make typecheck && make test-unit`
- Live OpenAI verification with root `.env`: `gpt-5.2`, `gpt-5.1`, and `gpt-5` reasoning-summary SDK calls; `gpt-5.2` and `gpt-5.1` produced non-empty reasoning blocks through the SDK.

Closes #70

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Enhanced reasoning response handling with support for summary list content
  - Optimized reasoning configuration logic for OpenAI models with improved gating

* **Tests**
  - Added comprehensive test coverage for reasoning summary handling and configuration assertions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siilisolutions/spaik-sdk/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->