### PR TITLE
Add Gemini 3.5 Flash and migrate 3.1 Flash-Lite to GA IDs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ ModelRegistry.GPT_5_5
 # Google
 ModelRegistry.GEMINI_2_5_FLASH
 ModelRegistry.GEMINI_2_5_PRO
+ModelRegistry.GEMINI_3_5_FLASH
 ModelRegistry.GEMINI_3_1_PRO
 
 # Azure AI Foundry and other provider families

--- a/packages/agent-sdk/.cursor/rules/model-update.mdc
+++ b/packages/agent-sdk/.cursor/rules/model-update.mdc
@@ -198,7 +198,7 @@ If adding a model from a brand new provider:
 
 ---
 
-## 6. MODELS IN REGISTRY (last updated 2026-04-29)
+## 6. MODELS IN REGISTRY (last updated 2026-05-26)
 
 This section is a snapshot — update it whenever you run a model update pass.
 
@@ -268,10 +268,12 @@ This section is a snapshot — update it whenever you run a model update pass.
 | `GEMINI_2_5_FLASH_LITE` | `gemini-2.5-flash-lite` | Fastest/cheapest in 2.5 family |
 | `GEMINI_2_5_FLASH` | `gemini-2.5-flash` | |
 | `GEMINI_2_5_PRO` | `gemini-2.5-pro` | |
-| `GEMINI_3_FLASH_PREVIEW` | `gemini-3-flash-preview` | |
-| `GEMINI_3_PRO_PREVIEW` | `gemini-3-pro-preview` | Shut down March 9, 2026; now points to Gemini 3.1 Pro Preview |
+| `GEMINI_3_FLASH` | `gemini-3-flash-preview` | Preview; GA successor is Gemini 3.5 Flash |
+| `GEMINI_3_5_FLASH` | `gemini-3.5-flash` | GA May 2026; $1.50/$9.00/MTok |
+| `GEMINI_3_PRO` | `gemini-3-pro-preview` | Deprecated on Google API March 9, 2026 |
 | `GEMINI_3_1_PRO` | `gemini-3.1-pro-preview` | 1M context |
-| `GEMINI_3_1_FLASH_LITE` | `gemini-3.1-flash-lite-preview` | 1M context |
+| `GEMINI_3_1_FLASH_LITE` | `gemini-3.1-flash-lite` | GA May 2026; $0.25/$1.50/MTok |
+| `GEMINI_3_1_FLASH_LITE_PREVIEW` | `gemini-3.1-flash-lite-preview` | Shut down May 25, 2026 |
 
 ---
 

--- a/packages/agent-sdk/spaik_sdk/llm/cost/builtin_cost_provider.py
+++ b/packages/agent-sdk/spaik_sdk/llm/cost/builtin_cost_provider.py
@@ -106,6 +106,9 @@ class BuiltinCostProvider(CostProvider):
         elif name.startswith("gemini-2.5-pro"):
             # Gemini 2.5 Pro: $1.25 input, $10.00 output per 1M tokens
             return TokenUsage(input_tokens=125, output_tokens=1000, reasoning_tokens=0, cache_creation_tokens=156, cache_read_tokens=12)
+        elif name.startswith("gemini-3.5-flash"):
+            # Gemini 3.5 Flash: $1.50 input, $9.00 output per 1M tokens
+            return TokenUsage(input_tokens=150, output_tokens=900, reasoning_tokens=0, cache_creation_tokens=188, cache_read_tokens=15)
         elif name.startswith("gemini-3.1-pro"):
             # Gemini 3.1 Pro: $2.00 input, $12.00 output per 1M tokens for prompts <= 200k tokens
             return TokenUsage(input_tokens=200, output_tokens=1200, reasoning_tokens=0, cache_creation_tokens=250, cache_read_tokens=20)

--- a/packages/agent-sdk/spaik_sdk/models/model_registry.py
+++ b/packages/agent-sdk/spaik_sdk/models/model_registry.py
@@ -70,10 +70,13 @@ class ModelRegistry:
     GEMINI_2_5_FLASH_MAY_2025 = LLMModel(family=LLMFamilies.GOOGLE, name="gemini-2.5-flash", prompt_caching=True)
     GEMINI_2_5_PRO_MAY_2025 = LLMModel(family=LLMFamilies.GOOGLE, name="gemini-2.5-pro", prompt_caching=True)
     GEMINI_3_FLASH = LLMModel(family=LLMFamilies.GOOGLE, name="gemini-3-flash-preview", prompt_caching=True)
+    GEMINI_3_5_FLASH = LLMModel(family=LLMFamilies.GOOGLE, name="gemini-3.5-flash", prompt_caching=True)
     # Gemini 3 Pro: deprecated on Google API March 9, 2026
     GEMINI_3_PRO = LLMModel(family=LLMFamilies.GOOGLE, name="gemini-3-pro-preview", prompt_caching=True)
     GEMINI_3_1_PRO = LLMModel(family=LLMFamilies.GOOGLE, name="gemini-3.1-pro-preview", prompt_caching=True)
-    GEMINI_3_1_FLASH_LITE = LLMModel(family=LLMFamilies.GOOGLE, name="gemini-3.1-flash-lite-preview", prompt_caching=True)
+    GEMINI_3_1_FLASH_LITE = LLMModel(family=LLMFamilies.GOOGLE, name="gemini-3.1-flash-lite", prompt_caching=True)
+    # Gemini 3.1 Flash-Lite preview: shut down May 25, 2026
+    GEMINI_3_1_FLASH_LITE_PREVIEW = LLMModel(family=LLMFamilies.GOOGLE, name="gemini-3.1-flash-lite-preview", prompt_caching=True)
 
     # DeepSeek models
     DEEPSEEK_V3 = LLMModel(family=LLMFamilies.DEEPSEEK, name="DeepSeek-V3-0324")
@@ -214,11 +217,13 @@ class ModelRegistry:
             "gemini 2.5 pro": cls.GEMINI_2_5_PRO,
             "gemini 3 flash": cls.GEMINI_3_FLASH,
             "gemini 3.0 flash": cls.GEMINI_3_FLASH,
+            "gemini 3.5 flash": cls.GEMINI_3_5_FLASH,
             "gemini 3 pro": cls.GEMINI_3_PRO,
             "gemini 3.0 pro": cls.GEMINI_3_PRO,
             "gemini 3.1 pro": cls.GEMINI_3_1_PRO,
             "gemini 3.1 pro preview": cls.GEMINI_3_1_PRO,
             "gemini 3.1 flash lite": cls.GEMINI_3_1_FLASH_LITE,
+            "gemini 3.1 flash lite preview": cls.GEMINI_3_1_FLASH_LITE_PREVIEW,
             # DeepSeek aliases
             "deepseek": cls.DEEPSEEK_V3_2,
             "deepseek v3": cls.DEEPSEEK_V3,

--- a/packages/agent-sdk/tests/unit/spaik_sdk/llm/cost/test_builtin_cost_provider.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/llm/cost/test_builtin_cost_provider.py
@@ -14,7 +14,9 @@ class TestBuiltinCostProvider:
             (ModelRegistry.GPT_5_5, 500, 3000, 50),
             (ModelRegistry.GPT_5_5_PRO, 3000, 18000, 0),
             (ModelRegistry.GEMINI_3_FLASH, 50, 300, 5),
+            (ModelRegistry.GEMINI_3_5_FLASH, 150, 900, 15),
             (ModelRegistry.GEMINI_3_1_PRO, 200, 1200, 20),
+            (ModelRegistry.GEMINI_3_1_FLASH_LITE, 25, 150, 2),
         ],
     )
     def test_latest_model_pricing(self, model, expected_input: int, expected_output: int, expected_cache_read: int):

--- a/packages/agent-sdk/tests/unit/spaik_sdk/models/factories/test_google_factory.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/models/factories/test_google_factory.py
@@ -70,9 +70,11 @@ class TestGoogleModelFactoryReasoning:
             ModelRegistry.GEMINI_2_5_FLASH,
             ModelRegistry.GEMINI_2_5_PRO,
             ModelRegistry.GEMINI_3_FLASH,
+            ModelRegistry.GEMINI_3_5_FLASH,
             ModelRegistry.GEMINI_3_PRO,
             ModelRegistry.GEMINI_3_1_PRO,
             ModelRegistry.GEMINI_3_1_FLASH_LITE,
+            ModelRegistry.GEMINI_3_1_FLASH_LITE_PREVIEW,
         ],
     )
     def test_reasoning_false_works_for_all_gemini_models(self, factory, model):
@@ -93,9 +95,11 @@ class TestGoogleModelFactoryReasoning:
             ModelRegistry.GEMINI_2_5_FLASH,
             ModelRegistry.GEMINI_2_5_PRO,
             ModelRegistry.GEMINI_3_FLASH,
+            ModelRegistry.GEMINI_3_5_FLASH,
             ModelRegistry.GEMINI_3_PRO,
             ModelRegistry.GEMINI_3_1_PRO,
             ModelRegistry.GEMINI_3_1_FLASH_LITE,
+            ModelRegistry.GEMINI_3_1_FLASH_LITE_PREVIEW,
         ],
     )
     def test_reasoning_true_works_for_all_gemini_models(self, factory, model):

--- a/packages/agent-sdk/tests/unit/spaik_sdk/models/test_model_registry.py
+++ b/packages/agent-sdk/tests/unit/spaik_sdk/models/test_model_registry.py
@@ -33,7 +33,9 @@ class TestModelRegistry:
             ("gemini 3 pro", "gemini-3-pro-preview"),
             ("gemini 3.0 pro", "gemini-3-pro-preview"),
             ("gemini 3.1 pro", "gemini-3.1-pro-preview"),
-            ("gemini 3.1 flash lite", "gemini-3.1-flash-lite-preview"),
+            ("gemini 3.5 flash", "gemini-3.5-flash"),
+            ("gemini 3.1 flash lite", "gemini-3.1-flash-lite"),
+            ("gemini 3.1 flash lite preview", "gemini-3.1-flash-lite-preview"),
         ],
     )
     def test_from_name_alias_lookup_new_models(self, alias: str, expected_model_name: str):
@@ -60,7 +62,9 @@ class TestModelRegistry:
             "gpt-5.5-pro",
             "gemini-3-flash-preview",
             "gemini-3-pro-preview",
+            "gemini-3.5-flash",
             "gemini-3.1-pro-preview",
+            "gemini-3.1-flash-lite",
             "gemini-3.1-flash-lite-preview",
         ],
     )
@@ -87,7 +91,9 @@ class TestModelRegistry:
         assert ModelRegistry.GEMINI_3_FLASH.family == LLMFamilies.GOOGLE
         assert ModelRegistry.GEMINI_3_PRO.family == LLMFamilies.GOOGLE
         assert ModelRegistry.GEMINI_3_1_PRO.family == LLMFamilies.GOOGLE
+        assert ModelRegistry.GEMINI_3_5_FLASH.family == LLMFamilies.GOOGLE
         assert ModelRegistry.GEMINI_3_1_FLASH_LITE.family == LLMFamilies.GOOGLE
+        assert ModelRegistry.GEMINI_3_1_FLASH_LITE_PREVIEW.family == LLMFamilies.GOOGLE
 
     def test_claude_opus_models_use_anthropic_family(self):
         assert ModelRegistry.CLAUDE_4_5_OPUS.family == LLMFamilies.ANTHROPIC
@@ -116,5 +122,7 @@ class TestModelRegistry:
         assert "gpt-5.5-pro" in model_names
         assert "gemini-3-flash-preview" in model_names
         assert "gemini-3-pro-preview" in model_names
+        assert "gemini-3.5-flash" in model_names
         assert "gemini-3.1-pro-preview" in model_names
+        assert "gemini-3.1-flash-lite" in model_names
         assert "gemini-3.1-flash-lite-preview" in model_names


### PR DESCRIPTION
Ran the model-update runbook on branch `chore/model-update-2026-05-26`. Verified Anthropic, OpenAI, and Google against official docs (May 26, 2026).

## Changes made

### New models
| Registry constant | API ID | Notes |
|---|---|---|
| `GEMINI_3_5_FLASH` | `gemini-3.5-flash` | GA May 19, 2026; thinking + caching; **$1.50 / $9.00 per MTok** |

### Updated models
| Constant | Before | After |
|---|---|---|
| `GEMINI_3_1_FLASH_LITE` | `gemini-3.1-flash-lite-preview` | `gemini-3.1-flash-lite` (GA May 7) |
| Alias `"gemini 3.1 flash lite"` | → preview | → GA model |

### Backward compatibility
- `GEMINI_3_1_FLASH_LITE_PREVIEW` kept for the shut-down preview (`gemini-3.1-flash-lite-preview`, retired **May 25, 2026**)
- Alias `"gemini 3.1 flash lite preview"` added

### Files touched
- `model_registry.py`, `builtin_cost_provider.py`, tests, `model-update.mdc`, root `README.md`

## No changes needed (already current)

- **Anthropic**: Opus 4.7, Sonnet 4.6, Haiku 4.5 — all present
- **OpenAI**: Through GPT-5.5 / GPT-5.5 Pro — all present
- **GPT-5.6**: Not in official API docs (leaks only) — **not added**

## Deprecation warnings (no registry removal)

| Model | Note |
|---|---|
| `claude-sonnet-4-20250514`, `claude-opus-4-20250514` | Retiring **June 15, 2026** |
| `gemini-3-pro-preview` | Deprecated March 9, 2026 (kept for compat) |
| `gemini-3.1-flash-lite-preview` | Shut down May 25, 2026 |

## Tests

Lint and typecheck passed. All 88 model-related unit tests passed. Five `test_base_agent` failures are pre-existing (`DEFAULT_MODEL` env not set) and unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Gemini 3.5 Flash model with pricing information.
  * Updated model registry with newer Gemini versions and improved distinction between preview and stable variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siilisolutions/spaik-sdk/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->